### PR TITLE
Persist training stats

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -7,7 +7,7 @@
 	</summary>
 	<description>Detect and warn about suspicious IPs logging into Nextcloud
 	</description>
-	<version>0.1.3</version>
+	<version>0.1.4</version>
 	<licence>agpl</licence>
 	<author>Christoph Wurst</author>
 	<namespace>SuspiciousLogin</namespace>

--- a/lib/Db/Model.php
+++ b/lib/Db/Model.php
@@ -28,11 +28,53 @@ namespace OCA\SuspiciousLogin\Db;
 use OCP\AppFramework\Db\Entity;
 
 /**
+ * @method string getType()
+ * @method void setType(string $type)
+ * @method string getAppVersion()
+ * @method void setAppVersion(string $version)
+ * @method int getSamplesPositive()
+ * @method void setSamplesPositive(int $samples)
+ * @method int getSamplesShuffled()
+ * @method void setSamplesShuffled(int $shuffled)
+ * @method int getSamplesRandom()
+ * @method void setSamplesRandom(int $samples)
+ * @method int getEpochs()
+ * @method void setEpochs(int $epochs)
+ * @method int getLayers()
+ * @method void setLayers(int $layers)
+ * @method int getVectorDim()
+ * @method void setVectorDim(int $dimensions)
+ * @method float getLearningRate()
+ * @method void setLearningRate(float $learningRate)
+ * @method float getPrecisionY()
+ * @method void setPrecisionY(float $precision)
+ * @method float getPrecisionN()
+ * @method void setPrecisionN(float $precision)
+ * @method float getRecallY()
+ * @method void setRecallY(float $recall)
+ * @method float getRecallN()
+ * @method void setRecallN(float $recall)
+ * @method int getDuration()
+ * @method void setDuration(int $layers)
  * @method int getCreatedAt()
  * @method void setCreatedAt(int $createdAt)
  */
 class Model extends Entity {
 
+	protected $type;
+	protected $appVersion;
+	protected $samplesPositive;
+	protected $samplesShuffled;
+	protected $samplesRandom;
+	protected $epochs;
+	protected $layers;
+	protected $vectorDim;
+	protected $learningRate;
+	protected $precisionY;
+	protected $precisionN;
+	protected $recallY;
+	protected $recallN;
+	protected $duration;
 	protected $createdAt;
 
 }

--- a/lib/Migration/Version0Date20181214080456.php
+++ b/lib/Migration/Version0Date20181214080456.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\SuspiciousLogin\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\SimpleMigrationStep;
+use OCP\Migration\IOutput;
+
+class Version0Date20181214080456 extends SimpleMigrationStep {
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 *
+	 * @return ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$table = $schema->getTable('suspicious_login_model');
+		$table->addColumn('type', 'string', [
+			'notnull' => false,
+			'length' => 32,
+		]);
+		$table->addColumn('app_version', 'integer', [
+			'notnull' => false,
+			'length' => 32,
+		]);
+		$table->addColumn('samples_positive', 'integer', [
+			'notnull' => false,
+			'length' => 4,
+		]);
+		$table->addColumn('samples_shuffled', 'integer', [
+			'notnull' => false,
+			'length' => 4,
+		]);
+		$table->addColumn('samples_random', 'integer', [
+			'notnull' => false,
+			'length' => 4,
+		]);
+		$table->addColumn('epochs', 'integer', [
+			'notnull' => false,
+			'length' => 4,
+		]);
+		$table->addColumn('layers', 'integer', [
+			'notnull' => false,
+			'length' => 4,
+		]);
+		$table->addColumn('vector_dim', 'integer', [
+			'notnull' => false,
+			'length' => 4,
+		]);
+		$table->addColumn('learning_rate', 'decimal', [
+			'notnull' => false,
+			'length' => 4,
+		]);
+		$table->addColumn('precision_y', 'decimal', [
+			'notnull' => false,
+			'length' => 4,
+		]);
+		$table->addColumn('precision_n', 'decimal', [
+			'notnull' => false,
+			'length' => 4,
+		]);
+		$table->addColumn('recall_y', 'decimal', [
+			'notnull' => false,
+			'length' => 4,
+		]);
+		$table->addColumn('recall_n', 'decimal', [
+			'notnull' => false,
+			'length' => 4,
+		]);
+		$table->addColumn('duration', 'integer', [
+			'notnull' => false,
+			'length' => 4,
+		]);
+
+		return $schema;
+	}
+
+}

--- a/lib/Migration/Version0Date20181214083108.php
+++ b/lib/Migration/Version0Date20181214083108.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\SuspiciousLogin\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\SimpleMigrationStep;
+use OCP\Migration\IOutput;
+
+class Version0Date20181214083108 extends SimpleMigrationStep {
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 *
+	 * @return ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$table = $schema->getTable('suspicious_login_model');
+		$table->getColumn('type')
+			->setLength(128);
+		$table->getColumn('learning_rate')
+			->setPrecision(10)
+			->setScale(5);
+		$table->getColumn('precision_y')
+			->setPrecision(10)
+			->setScale(5);
+		$table->getColumn('precision_n')
+			->setPrecision(10)
+			->setScale(5);
+		$table->getColumn('recall_y', 'decimal')
+			->setPrecision(10)
+			->setScale(5);
+		$table->getColumn('recall_n', 'decimal')
+			->setPrecision(10)
+			->setScale(5);
+
+		return $schema;
+	}
+
+}

--- a/lib/Service/ModelPersistenceService.php
+++ b/lib/Service/ModelPersistenceService.php
@@ -27,9 +27,11 @@ namespace OCA\SuspiciousLogin\Service;
 
 use function file_get_contents;
 use function file_put_contents;
+use OCA\SuspiciousLogin\AppInfo\Application;
 use OCA\SuspiciousLogin\Db\Model;
 use OCA\SuspiciousLogin\Db\ModelMapper;
 use OCA\SuspiciousLogin\Exception\ServiceException;
+use OCP\App\IAppManager;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\Files\IAppData;
 use OCP\Files\NotFoundException;
@@ -52,19 +54,25 @@ class ModelPersistenceService {
 	/** @var IAppData */
 	private $appData;
 
+	/** @var IAppManager */
+	private $appManager;
+
 	/** @var ITempManager */
 	private $tempManager;
 
 	/** @var ILogger */
 	private $logger;
 
+
 	public function __construct(ModelManager $modelManager,
 								ModelMapper $modelMapper,
 								IAppData $appData,
+								IAppManager $appManager,
 								ITempManager $tempManager,
 								ILogger $logger) {
 		$this->modelManager = $modelManager;
 		$this->appData = $appData;
+		$this->appManager = $appManager;
 		$this->modelMapper = $modelMapper;
 		$this->logger = $logger;
 		$this->tempManager = $tempManager;
@@ -111,6 +119,9 @@ class ModelPersistenceService {
 	 * @todo encapsulate in transaction to prevent inconsistencies
 	 */
 	public function persist(Estimator $estimator, Model $model) {
+		$model->setType(get_class($estimator));
+		$model->getAppVersion($this->appManager->getAppVersion(Application::APP_ID));
+
 		$this->modelMapper->insert($model);
 		try {
 			$modelsFolder = $this->appData->getFolder(self::APPDATA_MODELS_FOLDER);


### PR DESCRIPTION
This allows it to "fire and forget" training runs without having to worry about missing the result output.

Additionally it helps experimenting with parameter variations and picking the most reliable configuration.