### PR TITLE
Lower the default number of epochs to 250

### DIFF
--- a/lib/Command/TrainMLP.php
+++ b/lib/Command/TrainMLP.php
@@ -59,7 +59,7 @@ class TrainMLP extends Train {
 			'e',
 			InputOption::VALUE_OPTIONAL,
 			"number of epochs to train",
-			5000
+			250
 		);
 		$this->addOption(
 			'layers',


### PR DESCRIPTION
5000 epochs does not yield better results, so we can lower that and have faster
training runs.