### PR TITLE
Make trainings a bit faster with new default parameters

### DIFF
--- a/lib/Service/MLP/Config.php
+++ b/lib/Service/MLP/Config.php
@@ -56,11 +56,11 @@ class Config {
 
 	public static function default() {
 		return new static(
-			250,
-			10,
+			150,
+			14,
+			1.5,
 			1.0,
-			1.0,
-			0.05
+			0.07
 		);
 	}
 


### PR DESCRIPTION
These parameters have shown good results and are comparable with 250 and 350 epochs so I'm making the faster one the default.