### PR TITLE
Weight IPs in training data by their number of occurence

### DIFF
--- a/lib/Command/Predict.php
+++ b/lib/Command/Predict.php
@@ -1,24 +1,4 @@
 <?php
-/**
- * @copyright 2018 Christoph Wurst <christoph@winzerhof-wurst.at>
- *
- * @author 2018 Christoph Wurst <christoph@winzerhof-wurst.at>
- *
- * @license GNU AGPL version 3 or any later version
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
 
 declare(strict_types=1);
 
@@ -81,7 +61,7 @@ class Predict extends Command {
 		$uid = $input->getArgument('uid');
 		$ip = $input->getArgument('ip');
 		$modelId = $input->getArgument('model');
-		if ($this->estimatorService->predict($uid, $ip, $modelId)) {
+		if ($this->estimatorService->predict($uid, $ip, (int) $modelId)) {
 			$output->writeln("OK:   IP $ip is not suspicious");
 		} else {
 			$output->writeln("WARN: IP $ip is suspicious");

--- a/lib/Db/LoginAddressAggregated.php
+++ b/lib/Db/LoginAddressAggregated.php
@@ -26,6 +26,13 @@ namespace OCA\SuspiciousLogin\Db;
 
 use OCP\AppFramework\Db\Entity;
 
+/**
+ * @method string getUid()
+ * @method string getIp()
+ * @method int getSeen()
+ * @method int getFirstSeen()
+ * @method int getLastSeen()
+ */
 class LoginAddressAggregated extends Entity {
 
 	protected $uid;

--- a/lib/Service/DataSet.php
+++ b/lib/Service/DataSet.php
@@ -48,14 +48,19 @@ class DataSet implements ArrayAccess, Countable {
 	/**
 	 * @param LoginAddressAggregated[] $loginAddresses
 	 */
-	public static function fromLoginAddresses(array $loginAddresses): DataSet {
-		return new DataSet(array_map(function (LoginAddressAggregated $addr) {
-			return [
+	public static function fromLoginAddresses(array $loginAddresses, bool $weighted = true): DataSet {
+		$deep = array_map(function (LoginAddressAggregated $addr) use ($weighted) {
+			$multiplier = $weighted ? (int)log((int) $addr->getSeen(), 2) : 1;
+			return array_fill(0, $multiplier, [
 				'uid' => $addr->getUid(),
 				'ip' => $addr->getIp(),
 				'label' => Trainer::LABEL_POSITIVE,
-			];
-		}, $loginAddresses));
+			]);
+		}, $loginAddresses);
+
+		return new DataSet(
+			array_merge(...$deep)
+		);
 	}
 
 	public function asTrainingData(): array {


### PR DESCRIPTION
Fixes #21

## Local tests

Old logic: 10/12 trained models consider the most commonly used IP as suspicious :cry: 

New logic: 1/7 trained models considers it as suspicious :rocket: 