### PR TITLE
Cast the model ID only if not null

### DIFF
--- a/lib/Command/Predict.php
+++ b/lib/Command/Predict.php
@@ -61,7 +61,7 @@ class Predict extends Command {
 		$uid = $input->getArgument('uid');
 		$ip = $input->getArgument('ip');
 		$modelId = $input->getArgument('model');
-		if ($this->estimatorService->predict($uid, $ip, (int) $modelId)) {
+		if ($this->estimatorService->predict($uid, $ip, $modelId ? (int) $modelId : null)) {
 			$output->writeln("OK:   IP $ip is not suspicious");
 		} else {
 			$output->writeln("WARN: IP $ip is suspicious");


### PR DESCRIPTION
Otherwise it will try to load model `0` by default.