### PR TITLE
Fix handling of unsupported ipv6 addresses

### DIFF
--- a/lib/Service/Collection/IAddressCollectionStrategy.php
+++ b/lib/Service/Collection/IAddressCollectionStrategy.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\SuspiciousLogin\Service\Collection;
+
+interface IAddressCollectionStrategy {
+
+	public function collect(string $uid, string $ip, int $timestamp): void;
+
+}

--- a/lib/Service/Collection/IpV4Collector.php
+++ b/lib/Service/Collection/IpV4Collector.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\SuspiciousLogin\Service\Collection;
+
+use OCA\SuspiciousLogin\Db\LoginAddress;
+use OCA\SuspiciousLogin\Db\LoginAddressMapper;
+
+class IpV4Collector implements IAddressCollectionStrategy {
+
+	/** @var LoginAddressMapper */
+	private $addressMapper;
+
+	public function __construct(LoginAddressMapper $addressMapper) {
+		$this->addressMapper = $addressMapper;
+	}
+
+	public function collect(string $uid, string $ip, int $timestamp): void {
+		$addr = new LoginAddress();
+		$addr->setUid($uid);
+		$addr->setIp($ip);
+		$addr->setCreatedAt($timestamp);
+
+		$this->addressMapper->insert($addr);
+	}
+
+}

--- a/lib/Service/Collection/IpV6Collector.php
+++ b/lib/Service/Collection/IpV6Collector.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\SuspiciousLogin\Service\Collection;
+
+use OCP\ILogger;
+
+class IpV6Collector implements IAddressCollectionStrategy {
+
+	/** @var ILogger */
+	private $logger;
+
+	public function __construct(ILogger $logger) {
+		$this->logger = $logger;
+	}
+
+	/**
+	 * @todo implement db mapper
+	 */
+	public function collect(string $uid, string $ip, int $timestamp): void {
+		$this->logger->debug("IPv6 address not collected");
+	}
+
+}

--- a/lib/Service/LoginDataCollector.php
+++ b/lib/Service/LoginDataCollector.php
@@ -24,25 +24,47 @@ declare(strict_types=1);
 
 namespace OCA\SuspiciousLogin\Service;
 
-use OCA\SuspiciousLogin\Db\LoginAddress;
-use OCA\SuspiciousLogin\Db\LoginAddressMapper;
+use OCA\SuspiciousLogin\Service\Collection\IAddressCollectionStrategy;
+use OCA\SuspiciousLogin\Service\Collection\IpV4Collector;
+use OCA\SuspiciousLogin\Service\Collection\IpV6Collector;
+use OCA\SuspiciousLogin\Util\AddressClassifier;
+use OCP\ILogger;
 
 class LoginDataCollector {
 
-	/** @var LoginAddressMapper */
-	private $addressMapper;
+	/** @var IpV4Collector */
+	private $ipV4Collector;
 
-	public function __construct(LoginAddressMapper $addressMapper) {
-		$this->addressMapper = $addressMapper;
+	/** @var IpV6Collector */
+	private $ipV6Collector;
+
+	/** @var ILogger */
+	private $logger;
+
+	public function __construct(IpV4Collector $ipV4Collector, IpV6Collector $ipV6Collector, ILogger $logger) {
+		$this->ipV4Collector = $ipV4Collector;
+		$this->ipV6Collector = $ipV6Collector;
+		$this->logger = $logger;
 	}
 
-	public function collectSuccessfulLogin(string $uid, string $ip, int $timestamp) {
-		$addr = new LoginAddress();
-		$addr->setUid($uid);
-		$addr->setIp($ip);
-		$addr->setCreatedAt($timestamp);
+	private function getCollectionStrategy(string $ip): ?IAddressCollectionStrategy {
+		if (AddressClassifier::isIpV4($ip)) {
+			return $this->ipV4Collector;
+		} else if (AddressClassifier::isIpV6($ip)) {
+			return $this->ipV6Collector;
+		} else {
+			return null;
+		}
+	}
 
-		$this->addressMapper->insert($addr);
+	public function collectSuccessfulLogin(string $uid, string $ip, int $timestamp): void {
+		$strategy = $this->getCollectionStrategy($ip);
+		if ($strategy === null) {
+			$this->logger->error("Got invalid address <$ip>");
+			return;
+		}
+
+		$strategy->collect($uid, $ip, $timestamp);
 	}
 
 }

--- a/lib/Util/AddressClassifier.php
+++ b/lib/Util/AddressClassifier.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\SuspiciousLogin\Util;
+
+use function filter_var;
+
+class AddressClassifier {
+
+	public static function isIpV4(string $address): bool {
+		return filter_var($address, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) !== false;
+	}
+
+	public static function isIpV6(string $address): bool {
+		return filter_var($address, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) !== false;
+	}
+
+}


### PR DESCRIPTION
Ref https://github.com/nextcloud-gmbh/suspicious_login/issues/44

* Split collection code into different strategies based on IP type
* Move the existing collection code to the ipv4 collector
* Add a ipv6 noop collector
* Classify the IP address type before any prediction and consider anything non-ipv4 as suspicious

In the future we can
* Create a new mapper for ipv6
* Create a new classifier for ipv6
* Predict suspiciousness of ipv6 addresses on login

---

Tested with setting my local nginx to support ipv6, hence having client connections from ::1.