### PR TITLE
Add an IPv6 classifier

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -7,7 +7,7 @@
 	</summary>
 	<description>Detect and warn about suspicious IPs logging into Nextcloud
 	</description>
-	<version>2.0.2</version>
+	<version>2.1.0</version>
 	<licence>agpl</licence>
 	<author>Christoph Wurst</author>
 	<namespace>SuspiciousLogin</namespace>
@@ -31,7 +31,8 @@
 
 	<background-jobs>
 		<job>OCA\SuspiciousLogin\BackgroundJob\ETLJob</job>
-		<job>OCA\SuspiciousLogin\BackgroundJob\TrainJob</job>
+		<job>OCA\SuspiciousLogin\BackgroundJob\TrainJobIpV4</job>
+		<job>OCA\SuspiciousLogin\BackgroundJob\TrainJobIpV6</job>
 	</background-jobs>
 
 	<commands>

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,8 @@
     "description": "Detect and warn about suspicious IPs logging into Nextcloud",
     "type": "library",
     "require": {
-        "php-ai/php-ml": "^0.7.0 || ^0.8.0"
+        "php-ai/php-ml": "^0.7.0 || ^0.8.0",
+        "darsyn/ip": "^4.0"
     },
     "license": "AGPLv3",
     "authors": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,58 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a6f92967087134140a71a27f7d5e8c18",
+    "content-hash": "287b694ec287fcd2ffc5466b8f328d6b",
     "packages": [
+        {
+            "name": "darsyn/ip",
+            "version": "4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/darsyn/ip.git",
+                "reference": "36db5b2160190de65ea66db4eedf38b3cfaa4d94"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/darsyn/ip/zipball/36db5b2160190de65ea66db4eedf38b3cfaa4d94",
+                "reference": "36db5b2160190de65ea66db4eedf38b3cfaa4d94",
+                "shasum": ""
+            },
+            "require": {
+                "php-64bit": ">=5.6",
+                "php-ipv6": ">=5.6"
+            },
+            "suggest": {
+                "doctrine/dbal": "to use IP as a column type"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Darsyn\\IP\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Zan Baldwin",
+                    "email": "hello@zanbaldwin.com",
+                    "homepage": "https://zanbaldwin.com"
+                }
+            ],
+            "description": "An immutable IP Address value object that provides several different notations, including helper functions.",
+            "homepage": "https://github.com/darsyn/ip",
+            "keywords": [
+                "IP",
+                "immutable",
+                "ipv4",
+                "ipv6",
+                "library",
+                "value-object"
+            ],
+            "time": "2018-06-15T13:45:56+00:00"
+        },
         {
             "name": "php-ai/php-ml",
             "version": "0.8.0",
@@ -257,16 +307,16 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.9.1",
+            "version": "1.9.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "e6828efaba2c9b79f4499dae1d66ef8bfa7b2b72"
+                "reference": "007c053ae6f31bba39dfa19a7726f56e9763bbea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/e6828efaba2c9b79f4499dae1d66ef8bfa7b2b72",
-                "reference": "e6828efaba2c9b79f4499dae1d66ef8bfa7b2b72",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/007c053ae6f31bba39dfa19a7726f56e9763bbea",
+                "reference": "007c053ae6f31bba39dfa19a7726f56e9763bbea",
                 "shasum": ""
             },
             "require": {
@@ -301,7 +351,7 @@
                 "object",
                 "object graph"
             ],
-            "time": "2019-04-07T13:18:21+00:00"
+            "time": "2019-08-09T12:45:53+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -874,16 +924,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "7.5.14",
+            "version": "7.5.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "2834789aeb9ac182ad69bfdf9ae91856a59945ff"
+                "reference": "d79c053d972856b8b941bb233e39dc521a5093f0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/2834789aeb9ac182ad69bfdf9ae91856a59945ff",
-                "reference": "2834789aeb9ac182ad69bfdf9ae91856a59945ff",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/d79c053d972856b8b941bb233e39dc521a5093f0",
+                "reference": "d79c053d972856b8b941bb233e39dc521a5093f0",
                 "shasum": ""
             },
             "require": {
@@ -943,8 +993,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "role": "lead",
-                    "email": "sebastian@phpunit.de"
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
                 }
             ],
             "description": "The PHP Unit Testing framework.",
@@ -954,7 +1004,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2019-07-15T06:24:08+00:00"
+            "time": "2019-08-21T07:05:16+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -1176,16 +1226,16 @@
         },
         {
             "name": "sebastian/exporter",
-            "version": "3.1.0",
+            "version": "3.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "234199f4528de6d12aaa58b612e98f7d36adb937"
+                "reference": "06a9a5947f47b3029d76118eb5c22802e5869687"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/234199f4528de6d12aaa58b612e98f7d36adb937",
-                "reference": "234199f4528de6d12aaa58b612e98f7d36adb937",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/06a9a5947f47b3029d76118eb5c22802e5869687",
+                "reference": "06a9a5947f47b3029d76118eb5c22802e5869687",
                 "shasum": ""
             },
             "require": {
@@ -1213,6 +1263,10 @@
             ],
             "authors": [
                 {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
                     "name": "Jeff Welch",
                     "email": "whatthejeff@gmail.com"
                 },
@@ -1221,16 +1275,12 @@
                     "email": "github@wallbash.com"
                 },
                 {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@2bepublished.at"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                },
-                {
                     "name": "Adam Harvey",
                     "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
                 }
             ],
             "description": "Provides the functionality to export PHP variables for visualization",
@@ -1239,7 +1289,7 @@
                 "export",
                 "exporter"
             ],
-            "time": "2017-04-03T13:19:02+00:00"
+            "time": "2019-08-11T12:43:14+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -1582,16 +1632,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v4.3.3",
+            "version": "v4.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "856d35814cf287480465bb7a6c413bb7f5f5e69c"
+                "reference": "e89969c00d762349f078db1128506f7f3dcc0d4a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/856d35814cf287480465bb7a6c413bb7f5f5e69c",
-                "reference": "856d35814cf287480465bb7a6c413bb7f5f5e69c",
+                "url": "https://api.github.com/repos/symfony/process/zipball/e89969c00d762349f078db1128506f7f3dcc0d4a",
+                "reference": "e89969c00d762349f078db1128506f7f3dcc0d4a",
                 "shasum": ""
             },
             "require": {
@@ -1627,7 +1677,7 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2019-05-30T16:10:05+00:00"
+            "time": "2019-08-26T08:26:39+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -1671,16 +1721,16 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "1.4.0",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "83e253c8e0be5b0257b881e1827274667c5c17a9"
+                "reference": "88e6d84706d09a236046d686bbea96f07b3a34f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/83e253c8e0be5b0257b881e1827274667c5c17a9",
-                "reference": "83e253c8e0be5b0257b881e1827274667c5c17a9",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/88e6d84706d09a236046d686bbea96f07b3a34f4",
+                "reference": "88e6d84706d09a236046d686bbea96f07b3a34f4",
                 "shasum": ""
             },
             "require": {
@@ -1688,8 +1738,7 @@
                 "symfony/polyfill-ctype": "^1.8"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.6",
-                "sebastian/version": "^1.0.1"
+                "phpunit/phpunit": "^4.8.36 || ^7.5.13"
             },
             "type": "library",
             "extra": {
@@ -1718,7 +1767,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2018-12-25T11:19:39+00:00"
+            "time": "2019-08-24T08:43:50+00:00"
         }
     ],
     "aliases": [],

--- a/lib/BackgroundJob/TrainJobIpV4.php
+++ b/lib/BackgroundJob/TrainJobIpV4.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\SuspiciousLogin\BackgroundJob;
+
+use OCA\SuspiciousLogin\Exception\InsufficientDataException;
+use OCA\SuspiciousLogin\Service\Ipv4Strategy;
+use OCA\SuspiciousLogin\Service\MLP\Trainer;
+use OCA\SuspiciousLogin\Service\TrainingDataConfig;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\TimedJob;
+use OCP\ILogger;
+use Throwable;
+
+class TrainJobIpV4 extends TimedJob {
+
+	/** @var Trainer */
+	private $trainer;
+
+	/** @var ILogger */
+	private $logger;
+
+	public function __construct(Trainer $trainer,
+								ILogger $logger,
+								ITimeFactory $time) {
+		parent::__construct($time);
+
+		$this->setInterval(24 * 60 * 60);
+		$this->trainer = $trainer;
+		$this->logger = $logger;
+	}
+
+	/**
+	 * @param $argument
+	 *
+	 * @return mixed
+	 */
+	protected function run($argument) {
+		try {
+			$strategy = new Ipv4Strategy();
+			$this->trainer->train(
+				$strategy->getDefaultMlpConfig(),
+				TrainingDataConfig::default(),
+				$strategy
+			);
+		} catch (InsufficientDataException $ex) {
+			$this->logger->logException($ex, [
+				'level' => ILogger::INFO,
+				'message' => 'No suspicious login model for IPv4 trained because of insufficient data',
+			]);
+		} catch (Throwable $ex) {
+			$this->logger->logException($ex, [
+				'level' => ILogger::ERROR,
+				'message' => 'Caught unknown error during IPv4 background training',
+			]);
+		}
+	}
+
+}

--- a/lib/BackgroundJob/TrainJobIpV6.php
+++ b/lib/BackgroundJob/TrainJobIpV6.php
@@ -26,7 +26,8 @@ declare(strict_types=1);
 namespace OCA\SuspiciousLogin\BackgroundJob;
 
 use OCA\SuspiciousLogin\Exception\InsufficientDataException;
-use OCA\SuspiciousLogin\Service\MLP\Config;
+use OCA\SuspiciousLogin\Service\Ipv4Strategy;
+use OCA\SuspiciousLogin\Service\IpV6Strategy;
 use OCA\SuspiciousLogin\Service\MLP\Trainer;
 use OCA\SuspiciousLogin\Service\TrainingDataConfig;
 use OCP\AppFramework\Utility\ITimeFactory;
@@ -34,7 +35,7 @@ use OCP\BackgroundJob\TimedJob;
 use OCP\ILogger;
 use Throwable;
 
-class TrainJob extends TimedJob {
+class TrainJobIpV6 extends TimedJob {
 
 	/** @var Trainer */
 	private $trainer;
@@ -59,19 +60,21 @@ class TrainJob extends TimedJob {
 	 */
 	protected function run($argument) {
 		try {
+			$strategy = new IpV6Strategy();
 			$this->trainer->train(
-				Config::default(),
-				TrainingDataConfig::default()
+				$strategy->getDefaultMlpConfig(),
+				TrainingDataConfig::default(),
+				$strategy
 			);
 		} catch (InsufficientDataException $ex) {
 			$this->logger->logException($ex, [
-				'level' => ILogger::WARN,
-				'message' => 'No suspicious login model trained because of insufficient data',
+				'level' => ILogger::INFO,
+				'message' => 'No suspicious login model for IPv6 trained because of insufficient data',
 			]);
 		} catch (Throwable $ex) {
 			$this->logger->logException($ex, [
 				'level' => ILogger::ERROR,
-				'message' => 'Caught unknown error during a background training',
+				'message' => 'Caught unknown error during IPv6 background training',
 			]);
 		}
 	}

--- a/lib/Command/Predict.php
+++ b/lib/Command/Predict.php
@@ -25,9 +25,12 @@ declare(strict_types=1);
 namespace OCA\SuspiciousLogin\Command;
 
 use OCA\SuspiciousLogin\Service\EstimatorService;
+use OCA\SuspiciousLogin\Service\Ipv4Strategy;
+use OCA\SuspiciousLogin\Service\IpV6Strategy;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Predict extends Command {
@@ -55,13 +58,23 @@ class Predict extends Command {
 			InputArgument::OPTIONAL,
 			"persisted model id (latest if omited)"
 		);
+		$this->addOption(
+			'v6',
+			null,
+			InputOption::VALUE_NONE,
+			"train with IPv6 data"
+		);
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
 		$uid = $input->getArgument('uid');
 		$ip = $input->getArgument('ip');
 		$modelId = $input->getArgument('model');
-		if ($this->estimatorService->predict($uid, $ip, $modelId ? (int) $modelId : null)) {
+		if ($this->estimatorService->predict(
+			$uid,
+			$ip,
+			$input->getOption('v6') ? new IpV6Strategy() : new Ipv4Strategy(),
+			$modelId ? (int)$modelId : null)) {
 			$output->writeln("OK:   IP $ip is not suspicious");
 		} else {
 			$output->writeln("WARN: IP $ip is suspicious");

--- a/lib/Db/Model.php
+++ b/lib/Db/Model.php
@@ -59,6 +59,8 @@ use OCP\AppFramework\Db\Entity;
  * @method void setDuration(int $layers)
  * @method int getCreatedAt()
  * @method void setCreatedAt(int $createdAt)
+ * @method string getAddressType()
+ * @method void setAddressType(string $type)
  */
 class Model extends Entity implements JsonSerializable {
 
@@ -77,6 +79,7 @@ class Model extends Entity implements JsonSerializable {
 	protected $recallN;
 	protected $duration;
 	protected $createdAt;
+	protected $addressType;
 
 	public function jsonSerialize() {
 		return [
@@ -95,6 +98,7 @@ class Model extends Entity implements JsonSerializable {
 			'recallN' => $this->recallN,
 			'duration' => $this->duration,
 			'createdAt' => $this->createdAt,
+			'addressType' => $this->addressType,
 		];
 	}
 

--- a/lib/Db/ModelMapper.php
+++ b/lib/Db/ModelMapper.php
@@ -46,14 +46,17 @@ class ModelMapper extends QBMapper {
 	}
 
 	/**
+	 * @param string $addressType
+	 *
 	 * @return Model
 	 * @throws DoesNotExistException
 	 */
-	public function findLatest(): Model {
+	public function findLatest(string $addressType): Model {
 		$qb = $this->db->getQueryBuilder();
 
 		$query = $qb->select('*')
 			->from($this->getTableName())
+			->where($qb->expr()->eq('address_type', $qb->createNamedParameter($addressType)))
 			->orderBy('created_at', 'desc')
 			->setMaxResults(1);
 
@@ -62,14 +65,16 @@ class ModelMapper extends QBMapper {
 
 	/**
 	 * @param int $max maximum number of models
+	 * @param string $addressType
 	 *
 	 * @return Model[]
 	 */
-	public function findMostRecent(int $max): array {
+	public function findMostRecent(int $max, string $addressType): array {
 		$qb = $this->db->getQueryBuilder();
 
 		$query = $qb->select('*')
 			->from($this->getTableName())
+			->where($qb->expr()->eq('address_type', $qb->createNamedParameter($addressType)))
 			->orderBy('created_at', 'desc')
 			->setMaxResults($max);
 

--- a/lib/Listener/LoginListener.php
+++ b/lib/Listener/LoginListener.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * @author Christoph Wurst <christoph@winzerhof-wurst.at>

--- a/lib/Migration/Version2Date20190906100917.php
+++ b/lib/Migration/Version2Date20190906100917.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\SuspiciousLogin\Migration;
+
+use Closure;
+use OCA\SuspiciousLogin\Service\Ipv4Strategy;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\SimpleMigrationStep;
+use OCP\Migration\IOutput;
+
+class Version2Date20190906100917 extends SimpleMigrationStep {
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 *
+	 * @return ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$table = $schema->getTable('suspicious_login_model');
+		$table->addColumn('address_type', 'string', [
+			'notnull' => true,
+			'length' => 32,
+			'default' => Ipv4Strategy::getTypeName()
+		]);
+
+		return $schema;
+	}
+
+}

--- a/lib/Service/AUidIpVector.php
+++ b/lib/Service/AUidIpVector.php
@@ -29,15 +29,13 @@ use function array_merge;
 use function str_pad;
 use function substr;
 
-class UidIPVector {
-
-	const SIZE = 16 + 32;
+abstract class AUidIpVector {
 
 	/** @var string */
 	private $uid;
 
 	/** @var string */
-	private $ip;
+	protected $ip;
 
 	/** @var string */
 	private $label;
@@ -55,7 +53,7 @@ class UidIPVector {
 		return str_split($padded);
 	}
 
-	private function numStringsToBitArray(array $strings, $base, $padding): array {
+	protected function numStringsToBitArray(array $strings, $base, $padding): array {
 		$converted = array_reduce(array_map(function (string $s) use ($base, $padding) {
 			return $this->numStringToBitArray($s, $base, $padding);
 		}, $strings), 'array_merge', []);
@@ -81,15 +79,13 @@ class UidIPVector {
 	 *
 	 * @return array
 	 */
-	private function ipAsFeatureVector(): array {
-		$splitIp = explode('.', $this->ip);
-		return $this->numStringsToBitArray($splitIp, 10, 8);
-	}
+	abstract protected function ipAsFeatureVector(): array;
 
 	public function asFeatureVector(): array {
+		$v = $this->ipAsFeatureVector();
 		return array_merge(
 			$this->uidAsFeatureVector(),
-			$this->ipAsFeatureVector()
+			$v
 		);
 	}
 

--- a/lib/Service/AdminService.php
+++ b/lib/Service/AdminService.php
@@ -54,7 +54,10 @@ class AdminService {
 	public function getStatistics(): AppStatistics {
 		return new AppStatistics(
 			$this->isActive(),
-			$this->modelMapper->findMostRecent(14),
+			array_merge(
+				$this->modelMapper->findMostRecent(14, Ipv4Strategy::getTypeName()),
+				$this->modelMapper->findMostRecent(14, IpV6Strategy::getTypeName())
+			),
 			TrainingDataConfig::default(),
 			$this->getTrainingDataStats()
 		);
@@ -62,7 +65,7 @@ class AdminService {
 
 	protected function isActive(): bool {
 		try {
-			$this->modelMapper->findLatest();
+			$this->modelMapper->findLatest(Ipv4Strategy::getTypeName());
 			return true;
 		} catch (DoesNotExistException $ex) {
 			return false;

--- a/lib/Service/EstimatorService.php
+++ b/lib/Service/EstimatorService.php
@@ -51,12 +51,12 @@ class EstimatorService {
 	 * @return bool
 	 * @throws ServiceException
 	 */
-	public function predict(string $uid, string $ip, int $modelId = null): bool {
+	public function predict(string $uid, string $ip, IClassificationStrategy $strategy, int $modelId = null): bool {
 		try {
 			if ($modelId === null) {
 				$this->logger->debug("loading latest model");
 
-				$estimatorModel = $this->persistenceService->loadLatest();
+				$estimatorModel = $this->persistenceService->loadLatest($strategy);
 			} else {
 				$this->logger->debug("loading model $modelId");
 
@@ -73,8 +73,8 @@ class EstimatorService {
 				'uid' => $uid,
 				'ip' => $ip,
 				'label' => '',
-			]
-		]);
+			],
+		], $strategy);
 
 		$predictions = $estimatorModel->predict($data->asTrainingData());
 

--- a/lib/Service/IClassificationStrategy.php
+++ b/lib/Service/IClassificationStrategy.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+/**
+ * @copyright 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\SuspiciousLogin\Service;
+
+use OCA\SuspiciousLogin\Db\LoginAddressAggregatedMapper;
+use OCA\SuspiciousLogin\Service\MLP\Config;
+
+interface IClassificationStrategy {
+
+	public static function getTypeName(): string;
+
+	public function hasSufficientData(LoginAddressAggregatedMapper $loginAddressMapper, int $validationDays): bool;
+
+	public function findHistoricAndRecent(LoginAddressAggregatedMapper $loginAddressMapper, int $testingDays, int $validationDays): array;
+
+	public function newVector($uid, $ip, $label): AUidIpVector;
+
+	public function generateRandomIp(): string;
+
+	public function getSize(): int;
+
+	public function getDefaultMlpConfig(): Config;
+
+}

--- a/lib/Service/IpV6Strategy.php
+++ b/lib/Service/IpV6Strategy.php
@@ -1,0 +1,61 @@
+<?php declare(strict_types=1);
+
+/**
+ * @copyright 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\SuspiciousLogin\Service;
+
+use OCA\SuspiciousLogin\Db\LoginAddressAggregatedMapper;
+use OCA\SuspiciousLogin\Service\MLP\Config;
+
+class IpV6Strategy implements IClassificationStrategy {
+
+	public static function getTypeName(): string {
+		return 'ipv6';
+	}
+
+	public function hasSufficientData(LoginAddressAggregatedMapper $loginAddressMapper, int $validationDays): bool {
+		return $loginAddressMapper->hasSufficientIpV6Data($validationDays);
+	}
+
+	public function findHistoricAndRecent(LoginAddressAggregatedMapper $loginAddressMapper, int $testingDays, int $validationDays): array {
+		return $loginAddressMapper->findHistoricAndRecentIpv6($testingDays, $validationDays);
+	}
+
+	public function newVector($uid, $ip, $label): AUidIpVector {
+		return new UidIpV6Vector($uid, $ip, $label);
+	}
+
+	public function generateRandomIp(): string {
+		return implode(':', array_map(function () {
+			return base_convert(random_int(0, 2 ** 16 - 1), 10, 16);
+		}, range(0, 7)));
+	}
+
+	public function getSize(): int {
+		return 16 + 64;
+	}
+
+	public function getDefaultMlpConfig(): Config {
+		return Config::default()->setEpochs(20);
+	}
+
+}

--- a/lib/Service/Ipv4Strategy.php
+++ b/lib/Service/Ipv4Strategy.php
@@ -1,0 +1,61 @@
+<?php declare(strict_types=1);
+
+/**
+ * @copyright 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\SuspiciousLogin\Service;
+
+use OCA\SuspiciousLogin\Db\LoginAddressAggregatedMapper;
+use OCA\SuspiciousLogin\Service\MLP\Config;
+
+class Ipv4Strategy implements IClassificationStrategy {
+
+	public static function getTypeName(): string {
+		return 'ipv4';
+	}
+
+	public function hasSufficientData(LoginAddressAggregatedMapper $loginAddressMapper, int $validationDays): bool {
+		return $loginAddressMapper->hasSufficientIpV4Data($validationDays);
+	}
+
+	public function findHistoricAndRecent(LoginAddressAggregatedMapper $loginAddressMapper, int $testingDays, int $validationDays): array {
+		return $loginAddressMapper->findHistoricAndRecentIpv4($testingDays, $validationDays);
+	}
+
+	public function newVector($uid, $ip, $label): AUidIpVector {
+		return new UidIpV4Vector($uid, $ip, $label);
+	}
+
+	public function generateRandomIp(): string {
+		return implode('.', array_map(function () {
+			return random_int(0, 255);
+		}, range(0, 7)));
+	}
+
+	public function getSize(): int {
+		return 16 + 32;
+	}
+
+	public function getDefaultMlpConfig(): Config {
+		return Config::default();
+	}
+
+}

--- a/lib/Service/ModelPersistenceService.php
+++ b/lib/Service/ModelPersistenceService.php
@@ -89,9 +89,9 @@ class ModelPersistenceService {
 	 * @throws SerializeException
 	 * @throws ServiceException
 	 */
-	public function loadLatest(): Estimator {
+	public function loadLatest(IClassificationStrategy $strategy): Estimator {
 		try {
-			$latestModel = $this->modelMapper->findLatest();
+			$latestModel = $this->modelMapper->findLatest($strategy::getTypeName());
 		} catch (DoesNotExistException $e) {
 			$this->logger->debug("No models found. Can't load latest");
 			throw new ServiceException("No models found", 0, $e);
@@ -124,7 +124,7 @@ class ModelPersistenceService {
 
 	public function load(int $id): Estimator {
 		$cached = $this->getCached($id);
-		if (!is_null($cached)) {
+		if ($cached !== null) {
 			$this->logger->debug("using cached model $id");
 
 			$serialized = $cached;

--- a/lib/Service/UidIpV4Vector.php
+++ b/lib/Service/UidIpV4Vector.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+
+namespace OCA\SuspiciousLogin\Service;
+
+
+class UidIpV4Vector extends AUidIpVector {
+
+	/**
+	 * Convert the decimal ip notation w.x.y.z to a binary (32bit) vector
+	 *
+	 * @return array
+	 */
+	protected function ipAsFeatureVector(): array {
+		$splitIp = explode('.', $this->ip);
+		return $this->numStringsToBitArray($splitIp, 10, 8);
+	}
+}

--- a/lib/Service/UidIpV6Vector.php
+++ b/lib/Service/UidIpV6Vector.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+
+namespace OCA\SuspiciousLogin\Service;
+
+
+use function array_map;
+use function base_convert;
+use function bin2hex;
+use Darsyn\IP\Version\IPv6;
+use function str_pad;
+use function str_split;
+use function substr;
+
+class UidIpV6Vector extends AUidIpVector {
+
+	/**
+	 * Convert the decimal ip notation w.x.y.z to a binary (32bit) vector
+	 *
+	 * @return array
+	 */
+	protected function ipAsFeatureVector(): array {
+		$addr = IPv6::factory($this->ip);
+
+		$hex = bin2hex($addr->getBinary());
+		$padded = str_pad($hex, 32, '0', STR_PAD_LEFT);
+		$binString = implode('', array_map(function(string $h) {
+			return str_pad(base_convert($h, 16, 2), 4, '0', STR_PAD_LEFT);
+		}, str_split($padded)));
+		$mostSign = substr($binString, 0, 64);
+
+		return array_map(
+			function (string $bit) {
+				return (float)$bit;
+			},
+			str_split($mostSign)
+		);
+	}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1978,22 +1978,6 @@
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
     },
-    "axios": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
-      "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
-      "requires": {
-        "follow-redirects": "1.5.10",
-        "is-buffer": "^2.0.2"
-      },
-      "dependencies": {
-        "is-buffer": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
-          "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
-        }
-      }
-    },
     "babel-loader": {
       "version": "8.0.6",
       "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.0.6.tgz",
@@ -2815,21 +2799,6 @@
       "integrity": "sha1-sgOOhG3DO6pXlhKNCAS0VbjB4h0=",
       "dev": true
     },
-    "debug": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-      "requires": {
-        "ms": "2.0.0"
-      },
-      "dependencies": {
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        }
-      }
-    },
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
@@ -3333,14 +3302,6 @@
       "requires": {
         "inherits": "^2.0.3",
         "readable-stream": "^2.3.6"
-      }
-    },
-    "follow-redirects": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-      "requires": {
-        "debug": "=3.1.0"
       }
     },
     "for-in": {
@@ -4802,14 +4763,6 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
       "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
       "dev": true
-    },
-    "nextcloud-axios": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/nextcloud-axios/-/nextcloud-axios-0.2.1.tgz",
-      "integrity": "sha512-gzW/TXXGkxSgaIhLyPGOZ8Gs8t43i7cUpZNtDQh/UGecSn62AqjpSms+8YRw0NSJ0nhOdlqhFCFw/wb9XfYVjg==",
-      "requires": {
-        "axios": "^0.19.0"
-      }
     },
     "nextcloud-initial-state": {
       "version": "0.0.3",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "private": true,
   "dependencies": {
     "chart.js": "^2.8.0",
-    "nextcloud-axios": "^0.2.1",
     "nextcloud-initial-state": "0.0.3",
     "vue": "^2.6.10",
     "vue-chartjs": "^3.4.2"

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -28,30 +28,17 @@
 		<h3>{{ t('suspicious_login', 'Training data statistics') }}</h3>
 		<p>
 			{{ t('suspicious_login', 'So far the app has captured {total} logins (including client connections), of which {distinct} are distinct (IP, UID) tuples.', {
-				total: stats.trainingDataStats.loginsCaptured,
-				distinct: stats.trainingDataStats.loginsAggregated,
+			total: stats.trainingDataStats.loginsCaptured,
+			distinct: stats.trainingDataStats.loginsAggregated,
 			}) }}
 		</p>
-		<h3>{{ t('suspicious_login', 'Classifier model statistics') }}</h3>
-		<p v-if="!stats.active">
-			{{ t('suspicious_login', 'No classifier model has been trained yet. This most likely means that you just enabled the app recently. Because the training of a model requires good data, the app waits until logins of at least {days} days have been captured.', {
-				days: stats.trainingDataConfig.maxAge
-			}) }}
-		</p>
-		<p v-else>
-			{{ t('suspicious_login', 'During evaluation, the latest model (trained {time}) has shown to capture {recall}% of all suspicious logins (recall), whereas {precision}% of the logins classified as suspicious are indeed suspicious (precision). Below you see a visualization of historic model performance.', {
-				time: relativeModified(stats.recentModels[0].createdAt),
-				precision: stats.recentModels[0].precisionN * 100,
-				recall: stats.recentModels[0].recallN * 100
-			}) }}
-			<ModelPerformanceChart :models="stats.recentModels" :styles="chartStyles"/>
-		</p>
+		<ModelPerformance :title="t('suspicious_login', 'IPv4')" :stats="stats" address-type="ipv4"></ModelPerformance>
+		<ModelPerformance :title="t('suspicious_login', 'IPv6')" :stats="stats" address-type="ipv6"></ModelPerformance>
 	</div>
 </template>
 
 <script>
-	import Axios from 'nextcloud-axios';
-	import ModelPerformanceChart from './ModelPerformanceChart';
+	import ModelPerformance from './ModelPerformance';
 
 	export default {
 		name: 'AdminSettings',
@@ -62,20 +49,7 @@
 			},
 		},
 		components: {
-			ModelPerformanceChart
-		},
-		data() {
-			return {
-				chartStyles: {
-					height: '350px',
-					position: 'relative',
-				}
-			};
-		},
-		methods: {
-			relativeModified (ts) {
-				return OC.Util.relativeModifiedDate(ts * 1000);
-			}
+			ModelPerformance
 		}
 	}
 </script>

--- a/src/components/ModelPerformance.vue
+++ b/src/components/ModelPerformance.vue
@@ -1,0 +1,86 @@
+<!--
+  - @copyright 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
+  -
+  - @author 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
+  -
+  - @license GNU AGPL version 3 or any later version
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as
+  - published by the Free Software Foundation, either version 3 of the
+  - License, or (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<template>
+	<div>
+		<h3>{{ t('suspicious_login', 'Classifier model statistics') + ' (' + this.addressType + ')' }}</h3>
+		<p v-if="!stats.active || models.length === 0">
+			{{ t('suspicious_login', 'No classifier model has been trained yet. This most likely means that you just enabled the app recently. Because the training of a model requires good data, the app waits until logins of at least {days} days have been captured.', {
+			days: stats.trainingDataConfig.maxAge
+			}) }}
+		</p>
+		<p v-else>
+			{{ t('suspicious_login', 'During evaluation, the latest model (trained {time}) has shown to capture {recall}% of all suspicious logins (recall), whereas {precision}% of the logins classified as suspicious are indeed suspicious (precision). Below you see a visualization of historic model performance.', {
+			time: relativeModified(models[0].createdAt),
+			precision: models[0].precisionN * 100,
+			recall: models[0].recallN * 100
+			}) }}
+			<ModelPerformanceChart :models="models" :styles="chartStyles"></ModelPerformanceChart>
+		</p>
+	</div>
+</template>
+
+<script>
+	import ModelPerformanceChart from './ModelPerformanceChart';
+
+	export default {
+		name: 'ModelPerformance',
+		components: {
+			ModelPerformanceChart
+		},
+		props: {
+			title: {
+				type: String,
+				required: true,
+			},
+			stats: {
+				type: Object,
+				required: true,
+			},
+			addressType: {
+				type: String,
+				required: true,
+			}
+		},
+		data() {
+			return {
+				chartStyles: {
+					height: '350px',
+					position: 'relative',
+				}
+			};
+		},
+		computed: {
+			models() {
+				return this.stats.recentModels.filter(m => m.addressType === this.addressType)
+			},
+		},
+		methods: {
+			relativeModified (ts) {
+				return OC.Util.relativeModifiedDate(ts * 1000);
+			}
+		}
+	}
+</script>
+
+<style scoped>
+
+</style>

--- a/tests/Unit/Service/AdminServiceTest.php
+++ b/tests/Unit/Service/AdminServiceTest.php
@@ -69,7 +69,7 @@ class AdminServiceTest extends TestCase {
 		$this->modelMapper->expects($this->once())
 			->method('findLatest')
 			->willThrowException(new DoesNotExistException(''));
-		$this->modelMapper->expects($this->once())
+		$this->modelMapper->expects($this->exactly(2))
 			->method('findMostRecent')
 			->with(14)
 			->willReturn([]);
@@ -99,7 +99,7 @@ class AdminServiceTest extends TestCase {
 		$this->modelMapper->expects($this->once())
 			->method('findLatest')
 			->willReturn($model);
-		$this->modelMapper->expects($this->once())
+		$this->modelMapper->expects($this->exactly(2))
 			->method('findMostRecent')
 			->with(14)
 			->willReturn([$model]);
@@ -114,7 +114,7 @@ class AdminServiceTest extends TestCase {
 			->willReturn(20);
 		$expected = new AppStatistics(
 			true,
-			[$model],
+			[$model, $model],
 			TrainingDataConfig::default(),
 			new TrainingDataStatistics(200, 20)
 		);


### PR DESCRIPTION
Fixes https://github.com/nextcloud/suspicious_login/issues/44

* [x] Add IPv6 to binary converter
* [x] Add random IPv6 generator
* [x] Store IP version with persisted model metadata
* [x] Add a dedicated IPv6 background job for training
* [x] Add dedicated training config presets for v4/v6
* [x] Load only the corresponding model on login
* [x] Admin setting overhaul