### PR TITLE
Use the correct namespaces

### DIFF
--- a/lib/AppInfo/BootstrapSingleton.php
+++ b/lib/AppInfo/BootstrapSingleton.php
@@ -28,13 +28,12 @@ namespace OCA\SuspiciousLogin\AppInfo;
 
 use function call_user_func_array;
 use function func_get_args;
-use OCA\SuspiciousLogin\Event\LoginNotificationListener;
 use OCA\SuspiciousLogin\Event\SuspiciousLoginEvent;
 use OCA\SuspiciousLogin\Listener\LoginListener;
+use OCA\SuspiciousLogin\Listener\LoginNotificationListener;
 use OCA\SuspiciousLogin\Notifications\Notifier;
 use OCP\AppFramework\IAppContainer;
 use OCP\EventDispatcher\IEventDispatcher;
-use OCP\IL10N;
 use OCP\Notification\IManager;
 use OCP\Util;
 

--- a/lib/Listener/LoginNotificationListener.php
+++ b/lib/Listener/LoginNotificationListener.php
@@ -22,9 +22,10 @@ declare(strict_types=1);
  *
  */
 
-namespace OCA\SuspiciousLogin\Event;
+namespace OCA\SuspiciousLogin\Listener;
 
 use OCA\SuspiciousLogin\AppInfo\Application;
+use OCA\SuspiciousLogin\Event\SuspiciousLoginEvent;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;


### PR DESCRIPTION
Else the event doesn't get properly triggered of course since the file
can't be found to autoload.

Seems we merged to fast ;)