### PR TITLE
Persist the notification state of suspsicious login detections

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -7,7 +7,7 @@
 	</summary>
 	<description>Detect and warn about suspicious IPs logging into Nextcloud
 	</description>
-	<version>2.2.0</version>
+	<version>2.2.1</version>
 	<licence>agpl</licence>
 	<author>Christoph Wurst</author>
 	<namespace>SuspiciousLogin</namespace>

--- a/lib/Db/SuspiciousLogin.php
+++ b/lib/Db/SuspiciousLogin.php
@@ -37,6 +37,8 @@ use OCP\AppFramework\Db\Entity;
  * @method string getRequestId()
  * @method void setUrl(string $userAgent)
  * @method string getUrl()
+ * @method void setNotificationState(int|null $state)
+ * @method int|null getNotificationState()
  */
 class SuspiciousLogin extends Entity {
 
@@ -45,5 +47,6 @@ class SuspiciousLogin extends Entity {
 	protected $createdAt;
 	protected $requestId;
 	protected $url;
+	protected $notificationState;
 
 }

--- a/lib/Migration/Version2Date20190913144908.php
+++ b/lib/Migration/Version2Date20190913144908.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\SuspiciousLogin\Migration;
+
+use Closure;
+use OCA\SuspiciousLogin\Service\Ipv4Strategy;
+use OCA\SuspiciousLogin\Service\NotificationState;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\SimpleMigrationStep;
+use OCP\Migration\IOutput;
+
+class Version2Date20190913144908 extends SimpleMigrationStep {
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 *
+	 * @return ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$table = $schema->getTable('suspicious_login');
+		$table->addColumn('notification_state', 'integer', [
+			'notnull' => false,
+			'length' => 4,
+		]);
+
+		return $schema;
+	}
+
+}

--- a/lib/Service/NotificationState.php
+++ b/lib/Service/NotificationState.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types=1);
+
+namespace OCA\SuspiciousLogin\Service;
+
+class NotificationState {
+
+	public const SENT = 1;
+	public const NOT_SENT_DUPLICATE = 2;
+	public const NOT_SENT_PEAK_TWO_DAYS = 3;
+	public const NOT_SENT_PEAK_ONE_HOUR = 4;
+
+}


### PR DESCRIPTION
This should help debug accounts where lots of notifications are sent, even though we now have peak detection.