### PR TITLE
Always collect token login data

### DIFF
--- a/lib/Listener/LoginListener.php
+++ b/lib/Listener/LoginListener.php
@@ -59,16 +59,29 @@ class LoginListener implements IEventListener {
 			// Unrelated
 			return;
 		}
+
+		$this->handleClassification($event);
+		$this->handleDataCollection($event);
+	}
+
+	private function handleClassification(PostLoginEvent $event): void {
 		if ($event->isTokenLogin()) {
 			// We don't care about those
 			return;
 		}
 
-		$ip = $this->request->getRemoteAddress();
-		$now = $this->timeFactory->getTime();
+		$this->loginClassifier->process(
+			$event->getUid(),
+			$this->request->getRemoteAddress()
+		);
+	}
 
-		$this->loginClassifier->process($event->getUid(), $ip);
-		$this->loginDataCollector->collectSuccessfulLogin($event->getUid(), $ip, $now);
+	private function handleDataCollection(PostLoginEvent $event): void {
+		$this->loginDataCollector->collectSuccessfulLogin(
+			$event->getUid(),
+			$this->request->getRemoteAddress(),
+			$this->timeFactory->getTime()
+		);
 	}
 
 }

--- a/tests/Unit/Listener/LoginListenerTest.php
+++ b/tests/Unit/Listener/LoginListenerTest.php
@@ -1,0 +1,107 @@
+<?php declare(strict_types=1);
+
+/**
+ * @copyright 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\SuspiciousLogin\Tests\Listener;
+
+use ChristophWurst\Nextcloud\Testing\TestCase;
+use OCA\SuspiciousLogin\Event\PostLoginEvent;
+use OCA\SuspiciousLogin\Listener\LoginListener;
+use OCA\SuspiciousLogin\Service\LoginClassifier;
+use OCA\SuspiciousLogin\Service\LoginDataCollector;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\EventDispatcher\Event;
+use OCP\IRequest;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class LoginListenerTest extends TestCase {
+
+	/** @var IRequest|MockObject */
+	private $request;
+
+	/** @var ITimeFactory|MockObject */
+	private $timeFactory;
+
+	/** @var LoginClassifier|MockObject */
+	private $loginClassifier;
+
+	/** @var LoginDataCollector|MockObject */
+	private $loginDataCollector;
+
+	/** @var LoginListener */
+	private $listener;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->request = $this->createMock(IRequest::class);
+		$this->timeFactory = $this->createMock(ITimeFactory::class);
+		$this->loginClassifier = $this->createMock(LoginClassifier::class);
+		$this->loginDataCollector = $this->createMock(LoginDataCollector::class);
+
+		$this->listener = new LoginListener(
+			$this->request,
+			$this->timeFactory,
+			$this->loginClassifier,
+			$this->loginDataCollector
+		);
+	}
+
+	public function testHandleUnrelated(): void {
+		$event = $this->createMock(Event::class);
+		$this->loginClassifier->expects($this->never())
+			->method('process');
+
+		$this->listener->handle($event);
+	}
+
+	public function testHandleTokenLogin(): void {
+		$this->loginClassifier->expects($this->never())
+			->method('process');
+		$this->loginDataCollector->expects($this->once())
+			->method('collectSuccessfulLogin')
+			->with(
+				'user',
+				$this->anything(),
+				$this->anything()
+			);
+		$event = new PostLoginEvent('user', true);
+
+		$this->listener->handle($event);
+	}
+
+	public function testHandlePasswordLogin(): void {
+		$this->loginClassifier->expects($this->once())
+			->method('process');
+		$this->loginDataCollector->expects($this->once())
+			->method('collectSuccessfulLogin')
+			->with(
+				'user',
+				$this->anything(),
+				$this->anything()
+			);
+		$event = new PostLoginEvent('user', false);
+
+		$this->listener->handle($event);
+	}
+
+}


### PR DESCRIPTION
Regression introduced with https://github.com/nextcloud/suspicious_login/commit/e342d290286f123ef584cb5b2dd020580db2f8fa#diff-030c80dadb86b0a658dcf12b4b194f57. This change removed the collection of token login data, hence very little data was collected and the results suffered -> #181.

Fixes #181 