### PR TITLE
Organize app into train, optimize and estimator services

### DIFF
--- a/lib/BackgroundJob/TrainJobIpV4.php
+++ b/lib/BackgroundJob/TrainJobIpV4.php
@@ -27,8 +27,8 @@ namespace OCA\SuspiciousLogin\BackgroundJob;
 
 use OCA\SuspiciousLogin\Exception\InsufficientDataException;
 use OCA\SuspiciousLogin\Service\Ipv4Strategy;
-use OCA\SuspiciousLogin\Service\MLP\Trainer;
 use OCA\SuspiciousLogin\Service\TrainingDataConfig;
+use OCA\SuspiciousLogin\Service\TrainService;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\TimedJob;
 use OCP\ILogger;
@@ -36,19 +36,19 @@ use Throwable;
 
 class TrainJobIpV4 extends TimedJob {
 
-	/** @var Trainer */
-	private $trainer;
+	/** @var TrainService */
+	private $trainService;
 
 	/** @var ILogger */
 	private $logger;
 
-	public function __construct(Trainer $trainer,
+	public function __construct(TrainService $trainService,
 								ILogger $logger,
 								ITimeFactory $time) {
 		parent::__construct($time);
 
 		$this->setInterval(24 * 60 * 60);
-		$this->trainer = $trainer;
+		$this->trainService = $trainService;
 		$this->logger = $logger;
 	}
 
@@ -60,7 +60,7 @@ class TrainJobIpV4 extends TimedJob {
 	protected function run($argument) {
 		try {
 			$strategy = new Ipv4Strategy();
-			$this->trainer->train(
+			$this->trainService->train(
 				$strategy->getDefaultMlpConfig(),
 				TrainingDataConfig::default(),
 				$strategy

--- a/lib/BackgroundJob/TrainJobIpV6.php
+++ b/lib/BackgroundJob/TrainJobIpV6.php
@@ -27,8 +27,8 @@ namespace OCA\SuspiciousLogin\BackgroundJob;
 
 use OCA\SuspiciousLogin\Exception\InsufficientDataException;
 use OCA\SuspiciousLogin\Service\IpV6Strategy;
-use OCA\SuspiciousLogin\Service\MLP\Trainer;
 use OCA\SuspiciousLogin\Service\TrainingDataConfig;
+use OCA\SuspiciousLogin\Service\TrainService;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\TimedJob;
 use OCP\ILogger;
@@ -36,19 +36,19 @@ use Throwable;
 
 class TrainJobIpV6 extends TimedJob {
 
-	/** @var Trainer */
-	private $trainer;
+	/** @var TrainService */
+	private $trainService;
 
 	/** @var ILogger */
 	private $logger;
 
-	public function __construct(Trainer $trainer,
+	public function __construct(TrainService $trainService,
 								ILogger $logger,
 								ITimeFactory $time) {
 		parent::__construct($time);
 
 		$this->setInterval(24 * 60 * 60);
-		$this->trainer = $trainer;
+		$this->trainService = $trainService;
 		$this->logger = $logger;
 	}
 
@@ -60,7 +60,7 @@ class TrainJobIpV6 extends TimedJob {
 	protected function run($argument) {
 		try {
 			$strategy = new IpV6Strategy();
-			$this->trainer->train(
+			$this->trainService->train(
 				$strategy->getDefaultMlpConfig(),
 				TrainingDataConfig::default(),
 				$strategy

--- a/lib/Command/Optimize.php
+++ b/lib/Command/Optimize.php
@@ -26,7 +26,7 @@ namespace OCA\SuspiciousLogin\Command;
 
 use OCA\SuspiciousLogin\Service\Ipv4Strategy;
 use OCA\SuspiciousLogin\Service\IpV6Strategy;
-use OCA\SuspiciousLogin\Service\MLP\Optimizer;
+use OCA\SuspiciousLogin\Service\MLP\OptimizerService;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -35,12 +35,12 @@ use Symfony\Component\Console\Output\OutputInterface;
 class Optimize extends Command {
 	use ModelStatistics;
 
-	/** @var Optimizer */
-	private $optimizer;
+	/** @var OptimizerService */
+	private $optimizerService;
 
-	public function __construct(Optimizer $optimizer) {
+	public function __construct(OptimizerService $optimizer) {
 		parent::__construct("suspiciouslogin:optimize");
-		$this->optimizer = $optimizer;
+		$this->optimizerService = $optimizer;
 
 		$this->addOption(
 			'max-epochs',
@@ -59,7 +59,7 @@ class Optimize extends Command {
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
-		$this->optimizer->optimize(
+		$this->optimizerService->optimize(
 			(int)$input->getOption('max-epochs'),
 			$input->getOption('v6') ? new IpV6Strategy() : new Ipv4Strategy(),
 			$output

--- a/lib/Service/DataLoader.php
+++ b/lib/Service/DataLoader.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright 2021 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2021 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\SuspiciousLogin\Service;
+
+use OCA\SuspiciousLogin\Db\LoginAddressAggregated;
+use OCA\SuspiciousLogin\Db\LoginAddressAggregatedMapper;
+use OCA\SuspiciousLogin\Exception\InsufficientDataException;
+use OCA\SuspiciousLogin\Service\MLP\Config;
+use OCA\SuspiciousLogin\Service\MLP\Trainer;
+use Rubix\ML\Datasets\Dataset;
+use Rubix\ML\Datasets\Labeled;
+use function array_fill;
+use function array_map;
+use function array_merge;
+use function floor;
+use function log;
+use function max;
+
+class DataLoader {
+
+	/** @var LoginAddressAggregatedMapper */
+	private $loginAddressMapper;
+
+	/** @var NegativeSampleGenerator */
+	private $negativeSampleGenerator;
+
+	public function __construct(LoginAddressAggregatedMapper $loginAddressMapper,
+								NegativeSampleGenerator $negativeSampleGenerator) {
+		$this->loginAddressMapper = $loginAddressMapper;
+		$this->negativeSampleGenerator = $negativeSampleGenerator;
+	}
+
+	/**
+	 * @param Config $config
+	 * @param TrainingDataConfig $dataConfig
+	 * @param AClassificationStrategy $strategy
+	 *
+	 * @throws InsufficientDataException
+	 */
+	public function loadTrainingAndValidationData(Config $config,
+												  TrainingDataConfig $dataConfig,
+												  AClassificationStrategy $strategy): TrainingDataSet {
+		$testingDays = $dataConfig->getNow() - $dataConfig->getThreshold() * 60 * 60 * 24;
+		$validationDays = $dataConfig->getMaxAge() === -1 ? 0 : $dataConfig->getNow() - $dataConfig->getMaxAge() * 60 * 60 * 24;
+
+		if (!$strategy->hasSufficientData($this->loginAddressMapper, $validationDays)) {
+			throw new InsufficientDataException("Not enough data for the specified maximum age");
+		}
+		[$historyRaw, $recentRaw] = $strategy->findHistoricAndRecent(
+			$this->loginAddressMapper,
+
+			$testingDays,
+			$validationDays
+		);
+		if (empty($historyRaw)) {
+			throw new InsufficientDataException("No historic data available");
+		}
+		if (empty($recentRaw)) {
+			throw new InsufficientDataException("No recent data available");
+		}
+
+		$positives = $this->addressesToDataSet($historyRaw, $strategy);
+		$validationPositives = $this->addressesToDataSet($recentRaw, $strategy);
+		$numValidation = count($validationPositives);
+		$numPositives = count($positives);
+		$numRandomNegatives = max((int)floor($numPositives * $config->getRandomNegativeRate()), 1);
+		$numShuffledNegative = max((int)floor($numPositives * $config->getShuffledNegativeRate()), 1);
+		$randomNegatives = $this->negativeSampleGenerator->generateRandomFromPositiveSamples($positives, $numRandomNegatives, $strategy);
+		$shuffledNegatives = $this->negativeSampleGenerator->generateRandomFromPositiveSamples($positives, $numShuffledNegative, $strategy);
+
+		// Validation negatives are generated from all data (to have all UIDs), but shuffled
+		$all = $positives->merge($validationPositives);
+		$all->randomize();
+		$validationNegatives = $this->negativeSampleGenerator->generateRandomFromPositiveSamples($all, $numValidation, $strategy);
+		/** @var Labeled $validationSamples */
+		$validationSamples = $validationPositives->merge($validationNegatives);
+
+		/** @var Labeled $allSamples */
+		$allSamples = $positives->merge($randomNegatives)->merge($shuffledNegatives);
+		$allSamples->randomize();
+
+		return new TrainingDataSet(
+			$allSamples,
+			$validationSamples,
+			$numPositives,
+			$numShuffledNegative,
+			$numRandomNegatives
+		);
+	}
+
+	/**
+	 * @param LoginAddressAggregated[] $loginAddresses
+	 */
+	private function addressesToDataSet(array $loginAddresses, AClassificationStrategy $strategy): Dataset {
+		$deep = array_map(function (LoginAddressAggregated $addr) use ($strategy) {
+			$multiplier = (int)log((int)$addr->getSeen(), 2);
+			return array_fill(0, $multiplier, $strategy->newVector($addr->getUid(), $addr->getIp()));
+		}, $loginAddresses);
+		$samples = array_merge(...$deep);
+
+		return new Labeled(
+			$samples,
+			array_fill(0, count($samples), Trainer::LABEL_POSITIVE)
+		);
+	}
+}

--- a/lib/Service/EstimatorService.php
+++ b/lib/Service/EstimatorService.php
@@ -32,15 +32,15 @@ use RuntimeException;
 
 class EstimatorService {
 
-	/** @var ModelPersistenceService */
-	private $persistenceService;
+	/** @var ModelStore */
+	private $modelStore;
 
 	/** @var ILogger */
 	private $logger;
 
-	public function __construct(ModelPersistenceService $persistenceService,
+	public function __construct(ModelStore $modelStore,
 								ILogger $logger) {
-		$this->persistenceService = $persistenceService;
+		$this->modelStore = $modelStore;
 		$this->logger = $logger;
 	}
 
@@ -57,11 +57,11 @@ class EstimatorService {
 			if ($modelId === null) {
 				$this->logger->debug("loading latest model");
 
-				$estimator = $this->persistenceService->loadLatest($strategy);
+				$estimator = $this->modelStore->loadLatest($strategy);
 			} else {
 				$this->logger->debug("loading model $modelId");
 
-				$estimator = $this->persistenceService->load($modelId);
+				$estimator = $this->modelStore->load($modelId);
 			}
 		} catch (RuntimeException $e) {
 			throw new ServiceException("Could not load model $modelId to classify UID $uid and IP $ip: " . $e->getMessage(), $e->getCode(), $e);

--- a/lib/Service/MLP/Config.php
+++ b/lib/Service/MLP/Config.php
@@ -25,6 +25,9 @@ declare(strict_types=1);
 
 namespace OCA\SuspiciousLogin\Service\MLP;
 
+/**
+ * @psalm-immutable
+ */
 class Config {
 
 	/** @var int */
@@ -57,7 +60,7 @@ class Config {
 	public static function default() {
 		return new static(
 			200,
-			14,
+			20,
 			1.5,
 			1.0,
 			0.07

--- a/lib/Service/ModelStore.php
+++ b/lib/Service/ModelStore.php
@@ -45,7 +45,7 @@ use OCP\ILogger;
 use OCP\ITempManager;
 use function strlen;
 
-class ModelPersistenceService {
+class ModelStore {
 	public const APPDATA_MODELS_FOLDER = 'models';
 
 	/** @var ModelMapper */

--- a/lib/Service/TrainService.php
+++ b/lib/Service/TrainService.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright 2021 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2021 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\SuspiciousLogin\Service;
+
+use OCA\SuspiciousLogin\Db\Model;
+use OCA\SuspiciousLogin\Exception\InsufficientDataException;
+use OCA\SuspiciousLogin\Exception\ServiceException;
+use OCA\SuspiciousLogin\Service\MLP\Config;
+use OCA\SuspiciousLogin\Service\MLP\Trainer;
+
+class TrainService {
+
+	/** @var DataLoader */
+	private $dataLoader;
+
+	/** @var Trainer */
+	private $trainer;
+
+	/** @var ModelStore */
+	private $store;
+
+	public function __construct(DataLoader $dataLoader,
+								Trainer $trainer,
+								ModelStore $store) {
+		$this->trainer = $trainer;
+		$this->store = $store;
+		$this->dataLoader = $dataLoader;
+	}
+
+	/**
+	 * @param Config $config
+	 * @param TrainingDataConfig $dataConfig
+	 * @param AClassificationStrategy $strategy
+	 *
+	 * @return Model
+	 *
+	 * @throws InsufficientDataException
+	 * @throws ServiceException
+	 */
+	public function train(Config $config,
+						  TrainingDataConfig $dataConfig,
+						  AClassificationStrategy $strategy): Model {
+		// Load
+		$data = $this->dataLoader->loadTrainingAndValidationData(
+			$config,
+			$dataConfig,
+			$strategy
+		);
+
+		// Train
+		$result = $this->trainer->train(
+			$config,
+			$data,
+			$strategy
+		);
+
+		// Persist
+		$this->store->persist(
+			$result->getClassifier(),
+			$result->getModel()
+		);
+
+		return $result->getModel();
+	}
+}

--- a/lib/Service/TrainingDataSet.php
+++ b/lib/Service/TrainingDataSet.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright 2021 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2021 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\SuspiciousLogin\Service;
+
+use Rubix\ML\Datasets\Labeled;
+
+/**
+ * @psalm-immutable
+ */
+class TrainingDataSet {
+
+	/**
+	 * @var Labeled
+	 */
+	private $trainingData;
+	/**
+	 * @var Labeled
+	 */
+	private $validationData;
+	/**
+	 * @var int
+	 */
+	private $numPositives;
+	/**
+	 * @var int
+	 */
+	private $numShuffledNegatives;
+	/**
+	 * @var int
+	 */
+	private $numRandomNegatives;
+
+	public function __construct(Labeled $trainingData,
+								Labeled $validationData,
+								int $numPositives,
+								int $numShuffledNegatives,
+								int $numRandomNegatives) {
+		$this->trainingData = $trainingData;
+		$this->validationData = $validationData;
+		$this->numPositives = $numPositives;
+		$this->numShuffledNegatives = $numShuffledNegatives;
+		$this->numRandomNegatives = $numRandomNegatives;
+	}
+
+	/**
+	 * @return Labeled
+	 */
+	public function getTrainingData(): Labeled {
+		return $this->trainingData;
+	}
+
+	/**
+	 * @return Labeled
+	 */
+	public function getValidationData(): Labeled {
+		return $this->validationData;
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getNumPositives(): int {
+		return $this->numPositives;
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getNumShuffledNegatives(): int {
+		return $this->numShuffledNegatives;
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getNumRandomNegatives(): int {
+		return $this->numRandomNegatives;
+	}
+}

--- a/lib/Service/TrainingResult.php
+++ b/lib/Service/TrainingResult.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright 2021 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2021 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\SuspiciousLogin\Service;
+
+use OCA\SuspiciousLogin\Db\Model;
+use Rubix\ML\Estimator;
+
+class TrainingResult {
+
+	/** @var Estimator */
+	private $classifier;
+
+	/** @var Model */
+	private $model;
+
+	public function __construct(Estimator $classifier,
+								Model $model) {
+		$this->classifier = $classifier;
+		$this->model = $model;
+	}
+
+	/**
+	 * @return Estimator
+	 */
+	public function getClassifier(): Estimator {
+		return $this->classifier;
+	}
+
+	/**
+	 * @return Model
+	 */
+	public function getModel(): Model {
+		return $this->model;
+	}
+}


### PR DESCRIPTION
This moves code around into better fitting spots that I'll need for a few upcoming optimizations.

The only change is that the optimize process now operates on a single set of data instead of re-reading the latest data for every batch run. That will make the model comparison fairer.

The app now has three high level services
* Train service: transforms collected data into a model
  + Load data sets
  + Train a classifier
  + Persist the model
* Optimizer: find the best parameters for a given data set
  + Load data sets (but just once, so every training is comparable)
  + Train a bunch of classifiers
  + Print the results (but don't persist anything as this services is meant to find the best parameters, not model)
* Estimator: predict the suspiciousness of a given (UID, IP) tuple
  + Load the latest model/estimator
  + Run a prediction