### PR TITLE
Run the optimization truly parallel

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,8 @@
     "description": "Detect and warn about suspicious IPs logging into Nextcloud",
     "type": "library",
     "require": {
+        "amphp/amp": "^2.5",
+        "amphp/parallel": "^1.4",
         "darsyn/ip": "^4.0",
         "rubix/ml": "^0.3.1"
     },
@@ -26,6 +28,14 @@
         "nextcloud/coding-standard": "^0.5.0"
     },
 	"config": {
-		"sort-packages": true
+		"sort-packages": true,
+		"optimize-autoloader": true,
+		"classmap-authoritative": true,
+		"autoloader-suffix": "SuspiciousLogin"
+	},
+	"autoload" : {
+		"psr-4": {
+			"OCA\\SuspiciousLogin\\": "./lib/"
+		}
 	}
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cf92f39710a69385ebf4f84b7702b1ae",
+    "content-hash": "5f0b60e7ae816acdae38821ccc36103e",
     "packages": [
         {
             "name": "amphp/amp",

--- a/lib/Command/Optimize.php
+++ b/lib/Command/Optimize.php
@@ -64,5 +64,7 @@ class Optimize extends Command {
 			$input->getOption('v6') ? new IpV6Strategy() : new Ipv4Strategy(),
 			$output
 		);
+
+		return 0;
 	}
 }

--- a/lib/Service/MLP/Config.php
+++ b/lib/Service/MLP/Config.php
@@ -59,11 +59,11 @@ class Config {
 
 	public static function default() {
 		return new static(
-			200,
-			20,
+			50,
+			10,
 			1.5,
-			1.0,
-			0.07
+			0.9,
+			0.01
 		);
 	}
 

--- a/lib/Task/TrainTask.php
+++ b/lib/Task/TrainTask.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright 2021 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2021 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\SuspiciousLogin\Task;
+
+use Amp\Parallel\Worker\Environment;
+use Amp\Parallel\Worker\Task;
+use OC;
+use OCA\SuspiciousLogin\Service\AClassificationStrategy;
+use OCA\SuspiciousLogin\Service\MLP\Config;
+use OCA\SuspiciousLogin\Service\MLP\Trainer;
+use OCA\SuspiciousLogin\Service\TrainingDataSet;
+
+class TrainTask implements Task {
+
+	/** @var Config */
+	private $config;
+
+	/** @var TrainingDataSet */
+	private $dataSet;
+
+	/** @var AClassificationStrategy */
+	private $strategy;
+
+	public function __construct(Config $config,
+								TrainingDataSet $dataSet,
+								AClassificationStrategy $strategy) {
+		$this->config = $config;
+		$this->dataSet = $dataSet;
+		$this->strategy = $strategy;
+	}
+
+	public function run(Environment $environment) {
+		// TODO: only works if the app is placed into a sub-sub directory of Nextcloud
+		require_once __DIR__ . '/../../../../lib/base.php';
+
+		/** @var Trainer $trainer */
+		$trainer = OC::$server->get(Trainer::class);
+
+		$result = $trainer->train(
+			$this->config,
+			$this->dataSet,
+			$this->strategy
+		);
+
+		return $result->getModel();
+	}
+}


### PR DESCRIPTION
Instead of running each parameter set through the trainer x times in series we can run this step in parallel. That means we get a speedup of 5x (that was the old number of runs per parameter set). Now the optimization even runs 8 jobs in each step to gain some precision.

Some technical insight: amphp has an async event queue and allows us to spawn any blocking *task*. This task is a small class that gets deserialized in the main process and deserialized in a spawned worker process. So for 8 training runs we'll have a total of 9 php processes. This is a poor person's replacement for threads in php. Nevertheless the overhead of separate processes shouldn't bother us here for a task that runs several minutes.

![Bildschirmfoto von 2021-01-26 10-19-15](https://user-images.githubusercontent.com/1374172/105825510-f8a6b800-5fbf-11eb-860a-4ddc839db61a.png)

