### PR TITLE
Use actually shuffled data for shuffled samples

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1211,16 +1211,16 @@
     "packages-dev": [
         {
             "name": "christophwurst/nextcloud_testing",
-            "version": "v0.12.1",
+            "version": "v0.12.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ChristophWurst/nextcloud_testing.git",
-                "reference": "3cbba15c75b7442e21d661e16e84a549eec93f3f"
+                "reference": "f16ffe407e734ab6a8cd16e7ba7d1e2bad8cfefc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ChristophWurst/nextcloud_testing/zipball/3cbba15c75b7442e21d661e16e84a549eec93f3f",
-                "reference": "3cbba15c75b7442e21d661e16e84a549eec93f3f",
+                "url": "https://api.github.com/repos/ChristophWurst/nextcloud_testing/zipball/f16ffe407e734ab6a8cd16e7ba7d1e2bad8cfefc",
+                "reference": "f16ffe407e734ab6a8cd16e7ba7d1e2bad8cfefc",
                 "shasum": ""
             },
             "require": {
@@ -1250,9 +1250,9 @@
             "description": "Simple and fast unit and integration testing framework for Nextcloud, based on PHPUnit",
             "support": {
                 "issues": "https://github.com/ChristophWurst/nextcloud_testing/issues",
-                "source": "https://github.com/ChristophWurst/nextcloud_testing/tree/v0.12.1"
+                "source": "https://github.com/ChristophWurst/nextcloud_testing/tree/v0.12.3"
             },
-            "time": "2021-01-13T10:05:18+00:00"
+            "time": "2021-01-28T10:28:10+00:00"
         },
         {
             "name": "composer/semver",

--- a/lib/Service/DataLoader.php
+++ b/lib/Service/DataLoader.php
@@ -89,7 +89,7 @@ class DataLoader {
 		$numRandomNegatives = max((int)floor($numPositives * $config->getRandomNegativeRate()), 1);
 		$numShuffledNegative = max((int)floor($numPositives * $config->getShuffledNegativeRate()), 1);
 		$randomNegatives = $this->negativeSampleGenerator->generateRandomFromPositiveSamples($positives, $numRandomNegatives, $strategy);
-		$shuffledNegatives = $this->negativeSampleGenerator->generateRandomFromPositiveSamples($positives, $numShuffledNegative, $strategy);
+		$shuffledNegatives = $this->negativeSampleGenerator->generateShuffledFromPositiveSamples($positives, $numShuffledNegative, $strategy);
 
 		// Validation negatives are generated from all data (to have all UIDs), but shuffled
 		$all = $positives->merge($validationPositives);

--- a/tests/Unit/Service/NegativeSampleGeneratorTest.php
+++ b/tests/Unit/Service/NegativeSampleGeneratorTest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright 2021 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2021 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\SuspiciousLogin\tests\Unit\Service;
+
+use ChristophWurst\Nextcloud\Testing\ServiceMockObject;
+use ChristophWurst\Nextcloud\Testing\TestCase;
+use OCA\SuspiciousLogin\Service\AClassificationStrategy;
+use OCA\SuspiciousLogin\Service\MLP\Trainer;
+use OCA\SuspiciousLogin\Service\NegativeSampleGenerator;
+use Rubix\ML\Datasets\Unlabeled;
+use function array_fill;
+use function array_merge;
+use function array_slice;
+use function decbin;
+use function str_pad;
+use function str_split;
+
+class NegativeSampleGeneratorTest extends TestCase {
+
+	/** @var ServiceMockObject */
+	private $serviceMock;
+
+	/** @var NegativeSampleGenerator */
+	private $generator;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->serviceMock = $this->createServiceMock(NegativeSampleGenerator::class);
+		$this->generator = $this->serviceMock->getService();
+	}
+
+	public function testGenerateRandomFromSinglePositive(): void {
+		$uidVec = array_fill(0, 16, 0);
+		$positiveVec = array_fill(0, 32, 1);
+		$randVec = array_fill(0, 32, 2);
+		$positives = new Unlabeled([array_merge($uidVec, $positiveVec)]);
+		$strategy = $this->createMock(AClassificationStrategy::class);
+		$strategy->method('generateRandomIpVector')->willReturn($randVec);
+
+		$result = $this->generator->generateRandomFromPositiveSamples($positives, 1, $strategy);
+
+		self::assertCount(1, $result);
+		$first = $result[0];
+		self::assertEquals(
+			array_merge($uidVec, $randVec, [Trainer::LABEL_NEGATIVE]),
+			$first
+		);
+	}
+
+	public function testGenerateShuffledFromSinglePositive(): void {
+		$uidVec = array_fill(0, 16, 0);
+		$positiveVec = array_fill(0, 32, 1);
+		$positives = new Unlabeled([array_merge($uidVec, $positiveVec)]);
+
+		$result = $this->generator->generateShuffledFromPositiveSamples($positives, 1);
+
+		self::assertCount(1, $result);
+		$first = $result[0];
+		self::assertEquals(
+			array_merge($uidVec, $positiveVec, [Trainer::LABEL_NEGATIVE]),
+			$first
+		);
+	}
+
+	public function testGenerateShuffledFromSingleUnique(): void {
+		$positives = new Unlabeled([
+			array_merge(self::decToBitArray(1, 16), self::decToBitArray(1, 32)),
+			array_merge(self::decToBitArray(1, 16), self::decToBitArray(2, 32)),
+			array_merge(self::decToBitArray(1, 16), self::decToBitArray(3, 32)),
+
+			array_merge(self::decToBitArray(2, 16), self::decToBitArray(1, 32)), // dup
+			array_merge(self::decToBitArray(2, 16), self::decToBitArray(2, 32)), // dup
+			array_merge(self::decToBitArray(2, 16), self::decToBitArray(3, 32)), // dup
+			array_merge(self::decToBitArray(2, 16), self::decToBitArray(4, 32)), // uniq
+		]);
+
+		$result = $this->generator->generateShuffledFromPositiveSamples($positives, 1);
+
+		self::assertCount(1, $result);
+		$first = $result[0];
+		self::assertEquals(
+			self::decToBitArray(4, 32),
+			array_slice($first, 16, 32)
+		);
+	}
+
+	public function testGenerateMultipleShuffledFromLimitedUnique(): void {
+		$positives = new Unlabeled([
+			array_merge(self::decToBitArray(1, 16), self::decToBitArray(1, 32)),
+			array_merge(self::decToBitArray(1, 16), self::decToBitArray(2, 32)),
+			array_merge(self::decToBitArray(1, 16), self::decToBitArray(3, 32)), // uniq
+
+			array_merge(self::decToBitArray(2, 16), self::decToBitArray(1, 32)), // dup
+			array_merge(self::decToBitArray(2, 16), self::decToBitArray(2, 32)), // dup
+			array_merge(self::decToBitArray(2, 16), self::decToBitArray(4, 32)), // uniq
+		]);
+
+		$result = $this->generator->generateShuffledFromPositiveSamples($positives, 5);
+
+		self::assertCount(5, $result);
+		foreach ($result as $sample) {
+			$ipVec = array_slice($sample, 16, 32);
+
+			self::assertTrue(
+				$ipVec == self::decToBitArray(3, 32) ||
+				$ipVec === self::decToBitArray(4, 32),
+				'sample has a unique IP'
+			);
+		}
+	}
+
+	/**
+	 * @return int[]
+	 */
+	private static function decToBitArray(int $dec, int $length): array {
+		return array_map(
+			function (string $d): int {
+				return (int) $d;
+			},
+			str_split(str_pad(decbin($dec), $length, "0", STR_PAD_LEFT))
+		);
+	}
+}


### PR DESCRIPTION
Turns out the initial implementation of the algorithm invoked the wrong
method for shuffled data generation and therefore random samples were
used for what was believed to be shuffled.

:shrug: 