### PR TITLE
Print all individual optimizer results

### DIFF
--- a/lib/Service/MLP/Trainer.php
+++ b/lib/Service/MLP/Trainer.php
@@ -93,14 +93,14 @@ class Trainer {
 		$model->setLayers($config->getLayers());
 		$model->setVectorDim($strategy->getSize());
 		$model->setLearningRate($config->getLearningRate());
-		$model->setPrecisionY($report['classes']['y']['precision']);
-		$model->setPrecisionN($report['classes']['n']['recall']);
-		$model->setRecallY($report['classes']['y']['precision']);
-		$model->setRecallN($report['classes']['n']['recall']);
+		$model->setPrecisionY($report['classes'][self::LABEL_POSITIVE]['precision']);
+		$model->setPrecisionN($report['classes'][self::LABEL_NEGATIVE]['recall']);
+		$model->setRecallY($report['classes'][self::LABEL_POSITIVE]['precision']);
+		$model->setRecallN($report['classes'][self::LABEL_NEGATIVE]['recall']);
 		$model->setDuration($elapsed);
 		$model->setAddressType($strategy::getTypeName());
 		$model->setCreatedAt($this->timeFactory->getTime());
 
-		return new TrainingResult($classifier, $model);
+		return new TrainingResult($classifier, $model, $report);
 	}
 }

--- a/lib/Service/TrainingResult.php
+++ b/lib/Service/TrainingResult.php
@@ -27,6 +27,7 @@ namespace OCA\SuspiciousLogin\Service;
 
 use OCA\SuspiciousLogin\Db\Model;
 use Rubix\ML\Estimator;
+use Rubix\ML\Report;
 
 class TrainingResult {
 
@@ -36,23 +37,26 @@ class TrainingResult {
 	/** @var Model */
 	private $model;
 
+	/** @var Report */
+	private $report;
+
 	public function __construct(Estimator $classifier,
-								Model $model) {
+								Model $model,
+								Report $report) {
 		$this->classifier = $classifier;
 		$this->model = $model;
+		$this->report = $report;
 	}
 
-	/**
-	 * @return Estimator
-	 */
 	public function getClassifier(): Estimator {
 		return $this->classifier;
 	}
 
-	/**
-	 * @return Model
-	 */
 	public function getModel(): Model {
 		return $this->model;
+	}
+
+	public function getReport(): Report {
+		return $this->report;
 	}
 }

--- a/lib/Task/TrainTask.php
+++ b/lib/Task/TrainTask.php
@@ -65,6 +65,6 @@ class TrainTask implements Task {
 			$this->strategy
 		);
 
-		return $result->getModel();
+		return $result;
 	}
 }


### PR DESCRIPTION
The optimization trains the with the exact same parameters for 8 times to get an average performance estimation of the model. Before this patch there was one summary of the current *cost* (metric that tells how well a model performs) across all training results. Now it prints all results to give some insight into how similar or different the individual results are.

I've tested this all manually. I just need a reviewer for a sanity check :handshake: 