### PR TITLE
Fix (double) variable mix-up

### DIFF
--- a/lib/Service/AClassificationStrategy.php
+++ b/lib/Service/AClassificationStrategy.php
@@ -43,7 +43,7 @@ abstract class AClassificationStrategy {
 	/**
 	 * @return LoginAddressAggregated[][]
 	 */
-	abstract public function findHistoricAndRecent(LoginAddressAggregatedMapper $loginAddressMapper, int $testingDays, int $validationDays): array;
+	abstract public function findHistoricAndRecent(LoginAddressAggregatedMapper $loginAddressMapper, int $validationThreshold, int $maxAge): array;
 
 	/**
 	 * @return int[]

--- a/lib/Service/DataLoader.php
+++ b/lib/Service/DataLoader.php
@@ -63,17 +63,16 @@ class DataLoader {
 	public function loadTrainingAndValidationData(Config $config,
 												  TrainingDataConfig $dataConfig,
 												  AClassificationStrategy $strategy): TrainingDataSet {
-		$testingDays = $dataConfig->getNow() - $dataConfig->getThreshold() * 60 * 60 * 24;
-		$validationDays = $dataConfig->getMaxAge() === -1 ? 0 : $dataConfig->getNow() - $dataConfig->getMaxAge() * 60 * 60 * 24;
+		$validationThreshold = $dataConfig->getNow() - $dataConfig->getThreshold() * 60 * 60 * 24;
+		$maxAge = $dataConfig->getMaxAge() === -1 ? 0 : $dataConfig->getNow() - $dataConfig->getMaxAge() * 60 * 60 * 24;
 
-		if (!$strategy->hasSufficientData($this->loginAddressMapper, $validationDays)) {
+		if (!$strategy->hasSufficientData($this->loginAddressMapper, $maxAge)) {
 			throw new InsufficientDataException("Not enough data for the specified maximum age");
 		}
 		[$historyRaw, $recentRaw] = $strategy->findHistoricAndRecent(
 			$this->loginAddressMapper,
-
-			$testingDays,
-			$validationDays
+			$validationThreshold,
+			$maxAge
 		);
 		if (empty($historyRaw)) {
 			throw new InsufficientDataException("No historic data available");

--- a/lib/Service/IpV6Strategy.php
+++ b/lib/Service/IpV6Strategy.php
@@ -45,8 +45,8 @@ class IpV6Strategy extends AClassificationStrategy {
 		return $loginAddressMapper->hasSufficientIpV6Data($validationDays);
 	}
 
-	public function findHistoricAndRecent(LoginAddressAggregatedMapper $loginAddressMapper, int $testingDays, int $validationDays): array {
-		return $loginAddressMapper->findHistoricAndRecentIpv6($testingDays, $validationDays);
+	public function findHistoricAndRecent(LoginAddressAggregatedMapper $loginAddressMapper, int $validationThreshold, int $maxAge): array {
+		return $loginAddressMapper->findHistoricAndRecentIpv6($validationThreshold, $maxAge);
 	}
 
 	protected function ipToVec(string $ip): array {

--- a/lib/Service/Ipv4Strategy.php
+++ b/lib/Service/Ipv4Strategy.php
@@ -39,8 +39,8 @@ class Ipv4Strategy extends AClassificationStrategy {
 		return $loginAddressMapper->hasSufficientIpV4Data($validationDays);
 	}
 
-	public function findHistoricAndRecent(LoginAddressAggregatedMapper $loginAddressMapper, int $testingDays, int $validationDays): array {
-		return $loginAddressMapper->findHistoricAndRecentIpv4($testingDays, $validationDays);
+	public function findHistoricAndRecent(LoginAddressAggregatedMapper $loginAddressMapper, int $validationThreshold, int $maxAge): array {
+		return $loginAddressMapper->findHistoricAndRecentIpv4($validationThreshold, $maxAge);
 	}
 
 	public function generateRandomIpVector(): array {


### PR DESCRIPTION
In the *data loader* the validation threshold and the maximum age timestamps were mixed up. But the same also happened in the classification strategies. So in sum everything gave the correct result, but the naming is confused in both classes.