### PR TITLE
Fix and improve the MLP optimizer

### DIFF
--- a/lib/Command/Optimize.php
+++ b/lib/Command/Optimize.php
@@ -72,6 +72,11 @@ class Optimize extends Command {
 			$output->writeln('<comment>XDebug is active. This will slow down the training processes.</comment>');
 		}
 
+		// Prevent getting killed by a timeout
+		if (strpos(ini_get('disable_functions'), 'set_time_limit') === false) {
+			set_time_limit(0);
+		}
+
 		$this->optimizerService->optimize(
 			(int)$input->getOption('max-epochs'),
 			$input->getOption('v6') ? new IpV6Strategy() : new Ipv4Strategy(),

--- a/lib/Command/Train.php
+++ b/lib/Command/Train.php
@@ -154,9 +154,13 @@ class Train extends Command {
 			}
 			$output->writeln('Using ' . $strategy::getTypeName() . ' strategy');
 
-			$data = $this->loader->loadTrainingAndValidationData(
-				$config,
+			$collectedData = $this->loader->loadTrainingAndValidationData(
 				$trainingDataConfig,
+				$strategy
+			);
+			$data = $this->loader->generateRandomShuffledData(
+				$collectedData,
+				$config,
 				$strategy
 			);
 			$result = $this->trainer->train(

--- a/lib/Service/CollectedData.php
+++ b/lib/Service/CollectedData.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright 2021 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2021 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\SuspiciousLogin\Service;
+
+use Rubix\ML\Datasets\Labeled;
+
+class CollectedData {
+	/** @var Labeled */
+	private $trainingPositives;
+
+	/** @var Labeled */
+	private $validationPositives;
+
+	public function __construct(Labeled $trainingPositives,
+								Labeled $validationPositives) {
+		$this->trainingPositives = $trainingPositives;
+		$this->validationPositives = $validationPositives;
+	}
+
+	public function getTrainingPositives(): Labeled {
+		return $this->trainingPositives;
+	}
+
+	public function getValidationPositives(): Labeled {
+		return $this->validationPositives;
+	}
+}

--- a/lib/Service/TrainService.php
+++ b/lib/Service/TrainService.php
@@ -64,9 +64,13 @@ class TrainService {
 						  TrainingDataConfig $dataConfig,
 						  AClassificationStrategy $strategy): Model {
 		// Load
-		$data = $this->dataLoader->loadTrainingAndValidationData(
-			$config,
+		$collectedData = $this->dataLoader->loadTrainingAndValidationData(
 			$dataConfig,
+			$strategy
+		);
+		$data = $this->dataLoader->generateRandomShuffledData(
+			$collectedData,
+			$config,
 			$strategy
 		);
 


### PR DESCRIPTION
* Do not run into php max execution time
* Read collected DB data once, generate random negatives samples for
  every training run.
* Generate negative data in each task so it's run in parallel
* Fix the optimizer algorithm to always test the *next* config and not
  the current one. Without this patch the optimizer re-evaluated the
  already known "best" config and then picks the new random neighbor as
  better -> leading nowhere.