### PR TITLE
Allow time warps

### DIFF
--- a/lib/Command/Optimize.php
+++ b/lib/Command/Optimize.php
@@ -32,6 +32,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use function extension_loaded;
+use function time;
 
 class Optimize extends Command {
 	use ModelStatistics;
@@ -56,6 +57,13 @@ class Optimize extends Command {
 			InputOption::VALUE_NONE,
 			"train with IPv6 data"
 		);
+		$this->addOption(
+			'now',
+			null,
+			InputOption::VALUE_OPTIONAL,
+			"the current time as timestamp",
+			time()
+		);
 		$this->registerStatsOption();
 	}
 
@@ -67,6 +75,7 @@ class Optimize extends Command {
 		$this->optimizerService->optimize(
 			(int)$input->getOption('max-epochs'),
 			$input->getOption('v6') ? new IpV6Strategy() : new Ipv4Strategy(),
+			(int) $input->getOption('now'),
 			$output
 		);
 

--- a/lib/Command/Train.php
+++ b/lib/Command/Train.php
@@ -107,6 +107,13 @@ class Train extends Command {
 			InputOption::VALUE_NONE,
 			"train with IPv6 data"
 		);
+		$this->addOption(
+			'now',
+			null,
+			InputOption::VALUE_OPTIONAL,
+			"the current time as timestamp",
+			time()
+		);
 		$this->registerStatsOption();
 		$this->loader = $loader;
 	}
@@ -130,7 +137,7 @@ class Train extends Command {
 			$config = $config->setLearningRate((float)$input->getOption('learn-rate'));
 		}
 
-		$trainingDataConfig = TrainingDataConfig::default();
+		$trainingDataConfig = TrainingDataConfig::default((int) $input->getOption('now'));
 		if ($input->getOption('validation-threshold') !== null) {
 			$trainingDataConfig = $trainingDataConfig->setThreshold((int)$input->getOption('validation-threshold'));
 		}

--- a/lib/Service/MLP/OptimizerService.php
+++ b/lib/Service/MLP/OptimizerService.php
@@ -176,13 +176,14 @@ class OptimizerService {
 
 	public function optimize(int $maxEpochs,
 							 AClassificationStrategy $strategy,
+							 int $now = null,
 							 OutputInterface $output,
 							 int $parallelism = 8): void {
 		$epochs = 0;
 		$stepWidth = self::INITIAL_STEP_WIDTH;
 		// Start with random config if none was passed (breadth-first search)
 		$config = $this->getNeighborConfig($strategy->getDefaultMlpConfig(), $stepWidth);
-		$dataConfig = TrainingDataConfig::default();
+		$dataConfig = TrainingDataConfig::default($now);
 		$data = $this->loader->loadTrainingAndValidationData(
 			$config,
 			$dataConfig,

--- a/lib/Service/TrainingDataConfig.php
+++ b/lib/Service/TrainingDataConfig.php
@@ -26,6 +26,7 @@ declare(strict_types=1);
 namespace OCA\SuspiciousLogin\Service;
 
 use JsonSerializable;
+use function time;
 
 class TrainingDataConfig implements JsonSerializable {
 
@@ -46,8 +47,8 @@ class TrainingDataConfig implements JsonSerializable {
 		$this->now = $now;
 	}
 
-	public static function default() {
-		return new self(60, 7, time());
+	public static function default(int $time = null) {
+		return new self(60, 7, $time ?? time());
 	}
 
 	/**


### PR DESCRIPTION
During development I test training on data from production instances. As
time is important for the data sets, e.g. to split between historic and
recent data, these data sets get outdated really quick. In order to be
able to still use slightly older data for development and optimization,
this adds a parameter to specify the *current time*.