### PR TITLE
Return to the default "alpha" of rubix-ml's MLP

### DIFF
--- a/lib/Service/MLP/Trainer.php
+++ b/lib/Service/MLP/Trainer.php
@@ -74,7 +74,7 @@ class Trainer {
 			$layers,
 			128,
 			new Adam($config->getLearningRate()),
-			1e-3,
+			1e-4,
 			$config->getEpochs()
 		);
 		$classifier->train($dataSet->getTrainingData());


### PR DESCRIPTION
In order to specify the number of epochs I needed to pass a value for *alpha*. As I currently don't understand the important or range of the parameter I'm reverting to the default value of 1e-4 that is used in the original constructor. Changing the value was actually never intended, I must have made a typo.