### PR TITLE
Explicitly set defaults to null during migrations

### DIFF
--- a/lib/Migration/Version0Date20181214083108.php
+++ b/lib/Migration/Version0Date20181214083108.php
@@ -47,18 +47,23 @@ class Version0Date20181214083108 extends SimpleMigrationStep {
 			->setLength(128);
 		$table->getColumn('learning_rate')
 			->setPrecision(10)
+			->setDefault(null)
 			->setScale(5);
 		$table->getColumn('precision_y')
 			->setPrecision(10)
+			->setDefault(null)
 			->setScale(5);
 		$table->getColumn('precision_n')
 			->setPrecision(10)
+			->setDefault(null)
 			->setScale(5);
 		$table->getColumn('recall_y')
 			->setPrecision(10)
+			->setDefault(null)
 			->setScale(5);
 		$table->getColumn('recall_n')
 			->setPrecision(10)
+			->setDefault(null)
 			->setScale(5);
 
 		return $schema;


### PR DESCRIPTION
Specific environments run into SQL errors otherwise where the default is
set to 'NULL' rather than NULL.

Faulty SQL before

```sql
 ALTER TABLE oc_suspicious_login_model change `type` type varchar(128) DEFAULT 'NULL' COLLATE utf8mb4_bin,
            change `learning_rate` learning_rate         numeric(10, 5) DEFAULT 'NULL',
            change `precision_y` precision_y             numeric(10, 5) DEFAULT 'NULL',
            change `precision_n` precision_n             numeric(10, 5) DEFAULT 'NULL',
            change `recall_y` recall_y                   numeric(10, 5) DEFAULT 'NULL',
            change `recall_n` recall_n                   numeric(10, 5) DEFAULT 'NULL'); 
```