### PR TITLE
chore(deps): Overwrite schedule for vulnerability updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -54,6 +54,8 @@
 	"vulnerabilityAlerts": {
 		"enabled": true,
 		"semanticCommitType": "fix",
+		"schedule": "before 7am every weekday",
+		"dependencyDashboardApproval": false,
 		"commitMessageSuffix": ""
 	},
 	"osvVulnerabilityAlerts": true


### PR DESCRIPTION
The default schedule is to only bump on the first day of the month.