### PR TITLE
chore(deps): Enable bumps and pins for github actions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
 	"extends": [
 		"config:base",
+		"helpers:pinGitHubActionDigests",
 		":semanticCommits",
 		":dependencyDashboard"
 	],
@@ -26,6 +27,7 @@
 	],
 	"enabledManagers": [
 		"composer",
+		"github-actions",
 		"npm"
 	],
 	"ignoreDeps": [
@@ -44,6 +46,11 @@
 			"description": "Disable regular bumps for stable branches",
 			"enabled": false,
 			"matchBaseBranches": "/^stable(.)+/"
+		},
+		{
+			"description": "Bump Github actions monthly",
+			"matchManagers": ["github-actions"],
+			"extends": ["schedule:monthly"]
 		},
 		{
 			"matchBaseBranches": ["master"],

--- a/renovate.json
+++ b/renovate.json
@@ -22,6 +22,7 @@
 	"ignoreUnstable": false,
 	"baseBranches": [
 		"master",
+		"stable27",
 		"stable26",
 		"stable25"
 	],
@@ -50,6 +51,17 @@
 		{
 			"description": "Bump Github actions monthly",
 			"matchManagers": ["github-actions"],
+			"extends": ["schedule:monthly"]
+		},
+		{
+			"description": "Allow Github action minor/patch updates for stable branches",
+			"matchManagers": ["github-actions"],
+			"matchUpdateTypes": ["minor", "patch"],
+			"matchBaseBranches": [
+				"stable27",
+				"stable26",
+				"stable25"
+			],
 			"extends": ["schedule:monthly"]
 		},
 		{


### PR DESCRIPTION
… and update them on stable branches as well (e.g. the outdated and failing xmlling action)