### PR TITLE
chore(release): v6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,16 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## 5.0.0 - unreleased
+## 6.0.0
+### Added
+- Nextcloud 28 support
+### Changed
+New and updated translations
+Dependency updates
+### Removed
+- Nextcloud 27 support
+
+## 5.0.0
 ### Added
 - Nextcloud 27 support
 ### Changed

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -7,7 +7,7 @@
 	</summary>
 	<description>Detect and warn about suspicious IPs logging into Nextcloud
 	</description>
-	<version>6.0.0-dev</version>
+	<version>6.0.0</version>
 	<licence>agpl</licence>
 	<author>Christoph Wurst</author>
 	<namespace>SuspiciousLogin</namespace>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "suspicious_login",
-  "version": "6.0.0-dev",
+  "version": "6.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "suspicious_login",
-      "version": "6.0.0-dev",
+      "version": "6.0.0",
       "license": "AGPL-3.0",
       "dependencies": {
         "@nextcloud/initial-state": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "suspicious_login",
-  "version": "6.0.0-dev",
+  "version": "6.0.0",
   "description": "Detect and warn about suspicious IPs logging into Nextcloud",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
Ensures this shipped app doesn't show with a dev suffix when 28 is released.