### PR TITLE
fix(info.xml) Prevent installation in 32-bit environments

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -21,6 +21,7 @@
 	<repository>https://github.com/ChristophWurst/suspicious_login.git</repository>
 
 	<dependencies>
+		<php min-int-size="64"/>
 		<nextcloud min-version="29" max-version="29"/>
 	</dependencies>
 


### PR DESCRIPTION
Since a dependency (used for IPv6 handling) requires a 64-bit environment, prevent this app from being installed in 32-bit environments in order to avoid Composer's `php-64bit` enforcement from kicking in and triggering nextcloud/server#43157. While we already had `php-64bit` in place in our Composer config, Composer only recently started enforcing it in composer/composer#11334 apparently so this wasn't a problem until now. 

This fix provides a proper preventative measure (and one we can control) until when/if this app is okay for 32-bit environments.

Fixes nextcloud/server#43157