### PR TITLE
fix(32bit): drop darsyn/ip dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,6 @@
     "require": {
         "amphp/amp": "^2.6.2",
         "amphp/parallel": "^1.4.3",
-        "darsyn/ip": "^4.1.0",
         "rubix/ml": "dev-chore/bump-flysystem-v2.1.1"
     },
     "license": "AGPLv3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "691b05668c5903c6a1aa0ca0e9f40da7",
+    "content-hash": "27ce4f8be309bf4719b80fddea9ffaa1",
     "packages": [
         {
             "name": "amphp/amp",
@@ -498,65 +498,6 @@
                 }
             ],
             "time": "2021-10-25T18:29:10+00:00"
-        },
-        {
-            "name": "darsyn/ip",
-            "version": "4.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/darsyn/ip.git",
-                "reference": "93b139036afc9c45f6a36b83480a7302161665fc"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/darsyn/ip/zipball/93b139036afc9c45f6a36b83480a7302161665fc",
-                "reference": "93b139036afc9c45f6a36b83480a7302161665fc",
-                "shasum": ""
-            },
-            "require": {
-                "php-64bit": ">=5.6",
-                "php-ipv6": ">=5.6"
-            },
-            "require-dev": {
-                "doctrine/dbal": "^2.3",
-                "ext-pdo": "*",
-                "phpunit/phpunit": "*"
-            },
-            "suggest": {
-                "doctrine/dbal": "to use IP as a column type"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Darsyn\\IP\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Zan Baldwin",
-                    "email": "hello@zanbaldwin.com",
-                    "homepage": "https://zanbaldwin.com"
-                }
-            ],
-            "description": "An immutable IP Address value object that provides several different notations, including helper functions.",
-            "homepage": "https://github.com/darsyn/ip",
-            "keywords": [
-                "IP",
-                "immutable",
-                "ipv4",
-                "ipv6",
-                "library",
-                "value-object"
-            ],
-            "support": {
-                "issues": "https://github.com/darsyn/ip/issues",
-                "source": "https://github.com/darsyn/ip/tree/4.1.0"
-            },
-            "time": "2022-05-19T09:01:05+00:00"
         },
         {
             "name": "league/flysystem",

--- a/lib/Service/IpV6Strategy.php
+++ b/lib/Service/IpV6Strategy.php
@@ -6,6 +6,7 @@ declare(strict_types=1);
  * @copyright 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
  *
  * @author 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
+ * @author Richard Steinmetz <richard@steinmetz.cloud>
  *
  * @license GNU AGPL version 3 or any later version
  *
@@ -25,7 +26,7 @@ declare(strict_types=1);
 
 namespace OCA\SuspiciousLogin\Service;
 
-use Darsyn\IP\Version\IPv6;
+use InvalidArgumentException;
 use OCA\SuspiciousLogin\Db\LoginAddressAggregatedMapper;
 use OCA\SuspiciousLogin\Service\MLP\Config;
 use function array_map;
@@ -50,8 +51,12 @@ class IpV6Strategy extends AClassificationStrategy {
 	}
 
 	protected function ipToVec(string $ip): array {
-		$addr = IPv6::factory($ip);
-		$hex = bin2hex($addr->getBinary());
+		$addr = inet_pton($ip);
+		if ($addr === false) {
+			throw new InvalidArgumentException('Invalid IPv6 address');
+		}
+
+		$hex = bin2hex($addr);
 		$padded = str_pad($hex, 32, '0', STR_PAD_LEFT);
 		$binString = implode('', array_map(function (string $h) {
 			return str_pad(base_convert($h, 16, 2), 4, '0', STR_PAD_LEFT);


### PR DESCRIPTION
Fix #837
Fix https://github.com/nextcloud/server/issues/43157

Parse IPv6 addresses directly using built-in functions. I compared both binary representations of hundreds of random IPv6 addresses and they are exactly the same so we don't need to drop trained models.

Ref https://www.php.net/manual/en/function.inet-pton.php

---

Can be tested via:
```
occ suspiciouslogin:seed --v6
occ suspiciouslogin:train --v6
```