### PR TITLE
fix: Return type of Model::jsonSerialize() should be compatible with …

### DIFF
--- a/lib/Db/Model.php
+++ b/lib/Db/Model.php
@@ -80,7 +80,7 @@ class Model extends Entity implements JsonSerializable {
 	protected $createdAt;
 	protected $addressType;
 
-	public function jsonSerialize() {
+	public function jsonSerialize(): array {
 		return [
 			'type' => $this->type,
 			'appVersion' => $this->appVersion,


### PR DESCRIPTION
From production:
> Return type of OCA\\SuspiciousLogin\\Db\\Model::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice at /…/apps/suspicious_login/lib/Db/Model.php#83