### PR TITLE
Reduce log messages when no model found

### DIFF
--- a/lib/Exception/ModelNotFoundException.php
+++ b/lib/Exception/ModelNotFoundException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\SuspiciousLogin\Exception;
+
+class ModelNotFoundException extends ServiceException {
+}

--- a/lib/Service/EstimatorService.php
+++ b/lib/Service/EstimatorService.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace OCA\SuspiciousLogin\Service;
 
+use OCA\SuspiciousLogin\Exception\ModelNotFoundException;
 use OCA\SuspiciousLogin\Exception\ServiceException;
 use Psr\Log\LoggerInterface;
 use Rubix\ML\Datasets\Unlabeled;
@@ -28,6 +29,7 @@ class EstimatorService {
 	 * @param int|null $modelId
 	 *
 	 * @return bool
+	 * @throws ModelNotFoundException
 	 * @throws ServiceException
 	 */
 	public function predict(string $uid, string $ip, AClassificationStrategy $strategy, ?int $modelId = null): bool {

--- a/lib/Service/LoginClassifier.php
+++ b/lib/Service/LoginClassifier.php
@@ -12,6 +12,7 @@ namespace OCA\SuspiciousLogin\Service;
 use OCA\SuspiciousLogin\Db\SuspiciousLogin;
 use OCA\SuspiciousLogin\Db\SuspiciousLoginMapper;
 use OCA\SuspiciousLogin\Event\SuspiciousLoginEvent;
+use OCA\SuspiciousLogin\Exception\ModelNotFoundException;
 use OCA\SuspiciousLogin\Exception\ServiceException;
 use OCA\SuspiciousLogin\Util\AddressClassifier;
 use OCP\AppFramework\Utility\ITimeFactory;
@@ -75,9 +76,13 @@ class LoginClassifier {
 				// All good, carry on!
 				return;
 			}
-		} catch (ServiceException $ex) {
-			$this->logger->debug("Could not predict suspiciousness: " . $ex->getMessage());
+		} catch (ModelNotFoundException $ex) {
+			$this->logger->debug('Could not predict suspiciousness: ' . $ex->getMessage());
 			// This most likely means there is no trained model yet, so we return early here
+			return;
+		} catch (ServiceException $ex) {
+			$this->logger->warning("Could not predict suspiciousness: " . $ex->getMessage());
+			// There was an error loading the model, so we return early here
 			return;
 		}
 


### PR DESCRIPTION
This PR aims to fix #793.

I've separated the fact that a model could not be found from the other possible service exceptions. When such a case is found, it now only logs to the debug log. This might technically be duplicate, but I think it's good to include anyways for debugging purposes.