### PR TITLE
fix(LoginClassifier): Adjust log levels / reduce logging noise

### DIFF
--- a/lib/Service/LoginClassifier.php
+++ b/lib/Service/LoginClassifier.php
@@ -76,12 +76,12 @@ class LoginClassifier {
 				return;
 			}
 		} catch (ServiceException $ex) {
-			$this->logger->warning("Could not predict suspiciousness: " . $ex->getMessage());
+			$this->logger->debug("Could not predict suspiciousness: " . $ex->getMessage());
 			// This most likely means there is no trained model yet, so we return early here
 			return;
 		}
 
-		$this->logger->warning("Detected a login from a suspicious login. user=$uid ip=$ip strategy=" . $strategy::getTypeName());
+		$this->logger->info("Detected a login from a suspicious login. user=$uid ip=$ip strategy=" . $strategy::getTypeName());
 
 		$login = $this->persistSuspiciousLogin($uid, $ip);
 		$this->notifyUser($uid, $ip, $login);
@@ -138,7 +138,7 @@ class LoginClassifier {
 
 		$lastTwoDays = count($this->mapper->findRecentByUid($uid, $now - 60 * 60 * 24 * 2));
 		if ($lastTwoDays > 10) {
-			$this->logger->warning("Suspicious login peak detected: $uid received $lastTwoDays alerts in the last two days");
+			$this->logger->info("Suspicious login peak detected: $uid received $lastTwoDays alerts in the last two days");
 			$login->setNotificationState(NotificationState::NOT_SENT_PEAK_TWO_DAYS);
 			$this->mapper->update($login);
 			return;
@@ -146,7 +146,7 @@ class LoginClassifier {
 
 		$lastHour = count($this->mapper->findRecentByUid($uid, $now - 60 * 60));
 		if ($lastHour > 3) {
-			$this->logger->warning("Suspicious login peak detected: $uid received $lastHour alerts in the last hour");
+			$this->logger->info("Suspicious login peak detected: $uid received $lastHour alerts in the last hour");
 			$login->setNotificationState(NotificationState::NOT_SENT_PEAK_ONE_HOUR);
 			$this->mapper->update($login);
 			return;


### PR DESCRIPTION
While #152 addressed rate limiting notifications to users, we still have some logging outside of there that isn't covered.

* Adjusts log levels (Warning -> a mixture of Debug and Info) of the two main messages that aren't rate limited
* Adjusts log levels of the already rate limited messages to Info level (from Warning) to be more consistent with Brute Force Protection log levels

This cuts down on the log noise from "Detected a login from a suspicious login..." 

All logs remain available at the appropriate log levels if desired.

Fixes #303 