### PR TITLE
fix: inverted logo in notification

### DIFF
--- a/lib/Notifications/Notifier.php
+++ b/lib/Notifications/Notifier.php
@@ -89,7 +89,7 @@ class Notifier implements INotifier {
 					$l->t('A new login into your account was detected. The IP address %s was classified as suspicious. If this was you, you can ignore this message. Otherwise you should change your password.', $suspiciousIp) . $additionalText
 				);
 
-				$notification->setIcon($this->url->getAbsoluteURL($this->url->imagePath('suspicious_login', 'app.svg')));
+				$notification->setIcon($this->url->getAbsoluteURL($this->url->imagePath('suspicious_login', 'app-dark.svg')));
 
 				return $notification;
 			default:


### PR DESCRIPTION
Fixes https://github.com/nextcloud/suspicious_login/issues/910

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/1e2c799b-e3de-4a58-81be-558f5f27866f) | ![image](https://github.com/user-attachments/assets/705fea7a-d20b-4379-a5a9-b423f77a5d76) | 






