### PR TITLE
fix(NegativeSampleGenerator): Prevent duplicate user IDs when getting unique IPs

### DIFF
--- a/lib/Service/NegativeSampleGenerator.php
+++ b/lib/Service/NegativeSampleGenerator.php
@@ -22,6 +22,10 @@ use function range;
 use function str_split;
 
 class NegativeSampleGenerator {
+	/**
+	 * Get IP vectors exclusively used by one user.
+	 * Includes the user vector in second dimension of the returned array.
+	 */
 	private function getUniqueIPsPerUser(Dataset $positives): array {
 		$map = [];
 
@@ -35,7 +39,7 @@ class NegativeSampleGenerator {
 				$map[$ipVecStr] = [
 					$uidVecStr,
 				];
-			} else {
+			} elseif (!in_array($uidVecStr, $map[$ipVecStr])) {
 				$map[$ipVecStr][] = $uidVecStr;
 			}
 		}

--- a/tests/Unit/Service/NegativeSampleGeneratorTest.php
+++ b/tests/Unit/Service/NegativeSampleGeneratorTest.php
@@ -132,6 +132,7 @@ class NegativeSampleGeneratorTest extends TestCase {
 	 * DataSet can consist of multiple unique entries only. If not handled correctly,
 	 * this will result in an array without any IP. This tests the
 	 * correct handling. See GitHub issue #860 for more.
+	 * @return void
 	 */
 	public function testGenerateMultipleShuffledFromUniquesOnly(): void {
 		$positives = new Unlabeled([
@@ -151,7 +152,7 @@ class NegativeSampleGeneratorTest extends TestCase {
 			$ipVec = array_slice($sample, 16, 32);
 
 			self::assertTrue(
-				$ipVec == self::decToBitArray(1, 32) ||
+				$ipVec === self::decToBitArray(1, 32) ||
 				$ipVec === self::decToBitArray(2, 32),
 				'Sample has an unique IP'
 			);

--- a/tests/Unit/Service/NegativeSampleGeneratorTest.php
+++ b/tests/Unit/Service/NegativeSampleGeneratorTest.php
@@ -145,9 +145,9 @@ class NegativeSampleGeneratorTest extends TestCase {
 			array_merge(self::decToBitArray(2, 16), self::decToBitArray(2, 32)),
 		]);
 
-		$result = $this->generator->generateShuffledFromPositiveSamples($positives, 5);
+		$result = $this->generator->generateShuffledFromPositiveSamples($positives, 2);
 
-		self::assertCount(5, $result);
+		self::assertCount(2, $result);
 		foreach ($result as $sample) {
 			$ipVec = array_slice($sample, 16, 32);
 

--- a/tests/Unit/Service/NegativeSampleGeneratorTest.php
+++ b/tests/Unit/Service/NegativeSampleGeneratorTest.php
@@ -132,7 +132,6 @@ class NegativeSampleGeneratorTest extends TestCase {
 	 * DataSet can consist of multiple unique entries only. If not handled correctly,
 	 * this will result in an array without any IP. This tests the
 	 * correct handling. See GitHub issue #860 for more.
-	 * @return void
 	 */
 	public function testGenerateMultipleShuffledFromUniquesOnly(): void {
 		$positives = new Unlabeled([

--- a/tests/Unit/Service/NegativeSampleGeneratorTest.php
+++ b/tests/Unit/Service/NegativeSampleGeneratorTest.php
@@ -129,6 +129,37 @@ class NegativeSampleGeneratorTest extends TestCase {
 	}
 
 	/**
+	 * DataSet can consist of multiple unique entries only. If not handled correctly,
+	 * this will result in an array without any IP. This tests the
+	 * correct handling. See GitHub issue #860 for more.
+	 * @return void
+	 */
+	public function testGenerateMultipleShuffledFromUniquesOnly(): void {
+		$positives = new Unlabeled([
+			array_merge(self::decToBitArray(1, 16), self::decToBitArray(1, 32)),
+			array_merge(self::decToBitArray(1, 16), self::decToBitArray(1, 32)),
+			array_merge(self::decToBitArray(1, 16), self::decToBitArray(1, 32)),
+
+			array_merge(self::decToBitArray(2, 16), self::decToBitArray(2, 32)),
+			array_merge(self::decToBitArray(2, 16), self::decToBitArray(2, 32)),
+			array_merge(self::decToBitArray(2, 16), self::decToBitArray(2, 32)),
+		]);
+
+		$result = $this->generator->generateShuffledFromPositiveSamples($positives, 5);
+
+		self::assertCount(5, $result);
+		foreach ($result as $sample) {
+			$ipVec = array_slice($sample, 16, 32);
+
+			self::assertTrue(
+				$ipVec == self::decToBitArray(1, 32) ||
+				$ipVec === self::decToBitArray(2, 32),
+				'Sample has an unique IP'
+			);
+		}
+	}
+
+	/**
 	 * @return int[]
 	 */
 	private static function decToBitArray(int $dec, int $length): array {


### PR DESCRIPTION
To weight the usage of IPs in the data model, the user id is being added multiple times to the dataset. The exact number is being determined here: https://github.com/nextcloud/suspicious_login/blob/9043a660450844656d5bc63c6909242809003976/lib/Service/DataLoader.php#L80

The problem is that this isn't always being taken into account when generating the training data. In case the dataset contains no IP with *exactly* one user id in the array, the array is malformed by containing *only* user ids (16 columns in size) in this variable: https://github.com/nextcloud/suspicious_login/blob/9043a660450844656d5bc63c6909242809003976/lib/Service/DataLoader.php#L107
The reason is the code in the [`getUniqueIPsPerUser` function](https://github.com/nextcloud/suspicious_login/blob/9043a660450844656d5bc63c6909242809003976/lib/Service/NegativeSampleGenerator.php#L25). It returns only IPs with exactly one user id in the second dimension, while not checking if the user id was already added to the IP during the previous data transformation.

The Rubix ML library then throws an `InvalidArgumentException` due to the unequal number of columns when trying to merge the malformed array with the other datasets here:
https://github.com/nextcloud/suspicious_login/blob/9043a660450844656d5bc63c6909242809003976/lib/Service/DataLoader.php#L115

This PR will fix the issue and adds an unit test to prevent it during future refactoring steps.

Closes #860 
Closes #933 