### PR TITLE
fix: exclude vendor-bin from release artifacts

### DIFF
--- a/.nextcloudignore
+++ b/.nextcloudignore
@@ -30,4 +30,5 @@
 /tests
 .travis.yml
 /vendor/bin
+/vendor-bin
 /webpack.*


### PR DESCRIPTION
Reduce the size of release artifacts.

Remove 27M (2.9M compressed) from the release artifact.