### PR TITLE
fix: try to avoid memory exhaustion

### DIFF
--- a/lib/Db/LoginAddressAggregatedMapper.php
+++ b/lib/Db/LoginAddressAggregatedMapper.php
@@ -70,7 +70,9 @@ class LoginAddressAggregatedMapper extends QBMapper {
 				$qb->expr()->like('ip', $qb->createNamedParameter('_%._%._%._%')),
 				$qb->expr()->gte('last_seen', $qb->createNamedParameter($maxAge)),
 				$qb->expr()->lte('first_seen', $qb->createNamedParameter($threshold))
-			));
+			))
+			->orderBy('last_seen', 'DESC') // Use most recent data in case of limiting
+			->setMaxResults(15_000); // More data will like exhaust memory
 
 		return $this->findEntities($query);
 	}
@@ -84,7 +86,9 @@ class LoginAddressAggregatedMapper extends QBMapper {
 			->where($qb->expr()->andX(
 				$qb->expr()->like('ip', $qb->createNamedParameter('_%._%._%._%')),
 				$qb->expr()->gt('last_seen', $qb->createNamedParameter($threshold))
-			));
+			))
+			->orderBy('last_seen', 'DESC') // Use most recent data in case of limiting
+			->setMaxResults(3_000); // More data will like exhaust memory;
 
 		return $this->findEntities($query);
 	}
@@ -148,7 +152,9 @@ class LoginAddressAggregatedMapper extends QBMapper {
 				$qb->expr()->notLike('ip', $qb->createNamedParameter('_%._%._%._%')),
 				$qb->expr()->gte('last_seen', $qb->createNamedParameter($maxAge)),
 				$qb->expr()->lte('first_seen', $qb->createNamedParameter($threshold))
-			));
+			))
+			->orderBy('last_seen', 'DESC') // Use most recent data in case of limiting
+			->setMaxResults(15_000); // More data will like exhaust memory;
 
 		return $this->findEntities($query);
 	}
@@ -162,7 +168,9 @@ class LoginAddressAggregatedMapper extends QBMapper {
 			->where($qb->expr()->andX(
 				$qb->expr()->notLike('ip', $qb->createNamedParameter('_%._%._%._%')),
 				$qb->expr()->gt('last_seen', $qb->createNamedParameter($threshold))
-			));
+			))
+			->orderBy('last_seen', 'DESC') // Use most recent data in case of limiting
+			->setMaxResults(3_000); // More data will like exhaust memory
 
 		return $this->findEntities($query);
 	}

--- a/lib/Service/DataLoader.php
+++ b/lib/Service/DataLoader.php
@@ -22,8 +22,11 @@ use function array_merge;
 use function floor;
 use function log;
 use function max;
+use function random_int;
 
 class DataLoader {
+	private const MAX_SAMPLES_POSITIVES = 15_000;
+	private const MAX_SAMPLES_VALIDATE_POSITIVES = 3_000;
 
 	/** @var LoginAddressAggregatedMapper */
 	private $loginAddressMapper;
@@ -65,6 +68,14 @@ class DataLoader {
 
 		$positives = $this->addressesToDataSet($historyRaw, $strategy);
 		$validationPositives = $this->addressesToDataSet($recentRaw, $strategy);
+		if ($positives->count() > self::MAX_SAMPLES_POSITIVES) {
+			$threshold = (self::MAX_SAMPLES_POSITIVES / $positives->count()) * 100;
+			$positives = $positives->filter(fn () => random_int(0, 100) <= $threshold);
+		}
+		if ($validationPositives->count() > self::MAX_SAMPLES_VALIDATE_POSITIVES) {
+			$threshold = (self::MAX_SAMPLES_VALIDATE_POSITIVES / $validationPositives->count()) * 100;
+			$validationPositives = $validationPositives->filter(fn () => random_int(0, 100) <= $threshold);
+		}
 
 		return new CollectedData(
 			$positives,


### PR DESCRIPTION
On medium and large installations there can be a lot of login data. Loading it can exhaust the available PHP memory.

This limits the impact in two steps
1. Limit number of DB rows read
2. Limit number of datasets generated from DB results (DB results are deduplicated and we re-duplicate in memory)

master: I was not able to run ``occ suspiciouslogin:train --v6 --dry-run -vvv`` with a memory limit of 512M (Nextcloud default)
here: I can run ``occ suspiciouslogin:train --v6 --dry-run -vvv`` successfully with a memory limit of 256M