### PR TITLE
test: Set PHPUNIT_RUN env var

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -5,6 +5,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+define('PHPUNIT_RUN', 1);
+
 require_once __DIR__.'/../../../lib/base.php';
 require_once __DIR__.'/../vendor/autoload.php';
 


### PR DESCRIPTION
Tests fail right now. This might be the reason, because Nextcloud complains that config.php is not in the right format.