### PR TITLE
fix: rethrow exception when storing a model fails

### DIFF
--- a/lib/Service/ModelStore.php
+++ b/lib/Service/ModelStore.php
@@ -157,6 +157,7 @@ class ModelStore {
 				'exception' => $e,
 			]);
 			$this->modelMapper->delete($model);
+			throw $e;
 		}
 	}
 }


### PR DESCRIPTION
It fails and the process continues. 