### PR TITLE
fix(php): suppress notice of JsonSerializable::jsonSerialize

### DIFF
--- a/lib/Db/Model.php
+++ b/lib/Db/Model.php
@@ -11,6 +11,7 @@ namespace OCA\SuspiciousLogin\Db;
 
 use JsonSerializable;
 use OCP\AppFramework\Db\Entity;
+use ReturnTypeWillChange;
 
 /**
  * @method string getType()
@@ -64,6 +65,7 @@ class Model extends Entity implements JsonSerializable {
 	protected $createdAt;
 	protected $addressType;
 
+	#[ReturnTypeWillChange]
 	public function jsonSerialize(): array {
 		return [
 			'type' => $this->type,

--- a/lib/Service/Statistics/AppStatistics.php
+++ b/lib/Service/Statistics/AppStatistics.php
@@ -16,6 +16,7 @@ namespace OCA\SuspiciousLogin\Service\Statistics;
 use JsonSerializable;
 use OCA\SuspiciousLogin\Db\Model;
 use OCA\SuspiciousLogin\Service\TrainingDataConfig;
+use ReturnTypeWillChange;
 
 class AppStatistics implements JsonSerializable {
 
@@ -69,6 +70,7 @@ class AppStatistics implements JsonSerializable {
 		return $this->trainingDataStatistics;
 	}
 
+	#[ReturnTypeWillChange]
 	public function jsonSerialize(): array {
 		return [
 			'active' => $this->isActive(),

--- a/lib/Service/Statistics/TrainingDataStatistics.php
+++ b/lib/Service/Statistics/TrainingDataStatistics.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace OCA\SuspiciousLogin\Service\Statistics;
 
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 class TrainingDataStatistics implements JsonSerializable {
 
@@ -39,6 +40,7 @@ class TrainingDataStatistics implements JsonSerializable {
 		return $this->loginsAggregated;
 	}
 
+	#[ReturnTypeWillChange]
 	public function jsonSerialize(): array {
 		return [
 			'loginsCaptured' => $this->getLoginsCaptured(),

--- a/lib/Service/TrainingDataConfig.php
+++ b/lib/Service/TrainingDataConfig.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace OCA\SuspiciousLogin\Service;
 
 use JsonSerializable;
+use ReturnTypeWillChange;
 use function time;
 
 class TrainingDataConfig implements JsonSerializable {
@@ -89,6 +90,7 @@ class TrainingDataConfig implements JsonSerializable {
 		return $clone;
 	}
 
+	#[ReturnTypeWillChange]
 	public function jsonSerialize(): array {
 		return [
 			'maxAge' => $this->getMaxAge(),


### PR DESCRIPTION
Fixes 

```
 > phpunit -c tests/phpunit.xml tests/Unit
PHPUnit 9.6.3 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.2.28
Configuration: tests/phpunit.xml
Warning:       No code coverage driver available
Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!

PHP Fatal error:  During inheritance of JsonSerializable: Uncaught Return type of OCA\SuspiciousLogin\Service\Statistics\TrainingDataStatistics::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice

/home/runner/work/suspicious_login/suspicious_login/apps/suspicious_login/lib/Service/Statistics/TrainingDataStatistics.php:42
/home/runner/work/suspicious_login/suspicious_login/apps/suspicious_login/lib/Service/Statistics/TrainingDataStatistics.php:14
/home/runner/work/suspicious_login/suspicious_login/apps/suspicious_login/tests/Unit/Service/AdminServiceTest.php:73
 in /home/runner/work/suspicious_login/suspicious_login/apps/suspicious_login/lib/Service/Statistics/TrainingDataStatistics.php on line 14
Script phpunit -c tests/phpunit.xml tests/Unit handling the test:unit event returned with error code 255
...
Error: Process completed with exit code 255.
```

on CI