### PR TITLE
test: migrate PHPUnit configuration file to new schema

### DIFF
--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,28 +1,24 @@
-<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 	SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
 	SPDX-License-Identifier: CC0-1.0
 -->
-<phpunit bootstrap="bootstrap.php"
-	 verbose="true"
-	 convertDeprecationsToExceptions="true"
-	 timeoutForSmallTests="900"
-	 timeoutForMediumTests="900"
-	 timeoutForLargeTests="900">
-	<testsuite name="U2F app tests">
-		<directory suffix="Test.php">.</directory>
-	</testsuite><!-- filters for code coverage -->
-	<filter>
-		<whitelist>
-			<directory suffix=".php">../</directory>
-			<exclude>
-				<directory suffix=".php">../l10n</directory>
-				<directory suffix=".php">../tests</directory>
-			</exclude>
-		</whitelist>
-	</filter>
-	<logging>
-		<!-- and this is where your report will be written -->
-		<log type="coverage-clover" target="./clover.xml"/>
-	</logging>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="bootstrap.php" timeoutForSmallTests="900" timeoutForMediumTests="900" timeoutForLargeTests="900" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" cacheDirectory=".phpunit.cache">
+  <coverage>
+    <report>
+      <clover outputFile="./clover.xml"/>
+    </report>
+  </coverage>
+  <testsuite name="TOTP app tests">
+    <directory suffix="Test.php">.</directory>
+  </testsuite>
+  <source>
+    <include>
+      <directory suffix=".php">../</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">../l10n</directory>
+      <directory suffix=".php">../tests</directory>
+    </exclude>
+  </source>
 </phpunit>


### PR DESCRIPTION
Fixes the suggestion of

```
> phpunit -c tests/phpunit.xml tests/Unit
PHPUnit 9.6.3 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.2.28
Configuration: tests/phpunit.xml
Warning:       No code coverage driver available
Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!

…
```

