### PR TITLE
fix(deps): bump amphp/parallel to v1.4.4. for PHP8.4 compatibility

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -168,16 +168,16 @@
         },
         {
             "name": "amphp/parallel",
-            "version": "v1.4.3",
+            "version": "v1.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/parallel.git",
-                "reference": "3aac213ba7858566fd83d38ccb85b91b2d652cb0"
+                "reference": "508ca221f2f47235327db5120f0a89d43435b69b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/parallel/zipball/3aac213ba7858566fd83d38ccb85b91b2d652cb0",
-                "reference": "3aac213ba7858566fd83d38ccb85b91b2d652cb0",
+                "url": "https://api.github.com/repos/amphp/parallel/zipball/508ca221f2f47235327db5120f0a89d43435b69b",
+                "reference": "508ca221f2f47235327db5120f0a89d43435b69b",
                 "shasum": ""
             },
             "require": {
@@ -190,9 +190,9 @@
                 "php": ">=7.1"
             },
             "require-dev": {
-                "amphp/php-cs-fixer-config": "dev-master",
+                "amphp/php-cs-fixer-config": "^2",
                 "amphp/phpunit-util": "^1.1",
-                "phpunit/phpunit": "^8 || ^7"
+                "phpunit/phpunit": "^9 || ^8 || ^7"
             },
             "type": "library",
             "autoload": {
@@ -230,7 +230,7 @@
             ],
             "support": {
                 "issues": "https://github.com/amphp/parallel/issues",
-                "source": "https://github.com/amphp/parallel/tree/v1.4.3"
+                "source": "https://github.com/amphp/parallel/tree/v1.4.4"
             },
             "funding": [
                 {
@@ -238,7 +238,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-03-23T08:04:23+00:00"
+            "time": "2024-12-08T16:28:11+00:00"
         },
         {
             "name": "amphp/parser",


### PR DESCRIPTION
Ref https://github.com/amphp/parallel/issues/220

Fixes

```
PHP Deprecated:  Amp\Parallel\Worker\pool(): Implicitly marking parameter $pool as nullable is deprecated, the explicit nullable type must be used instead in /home/runner/work/suspicious_login/suspicious_login/apps/suspicious_login/vendor/amphp/parallel/lib/Worker/functions.php on line 18
PHP Deprecated:  Amp\Parallel\Worker\factory(): Implicitly marking parameter $factory as nullable is deprecated, the explicit nullable type must be used instead in /home/runner/work/suspicious_login/suspicious_login/apps/suspicious_login/vendor/amphp/parallel/lib/Worker/functions.php on line 85
```