### PR TITLE
Change attribute name "f1_score" to "f1 score" due to RubixML change

### DIFF
--- a/lib/Service/MLP/OptimizerService.php
+++ b/lib/Service/MLP/OptimizerService.php
@@ -72,20 +72,20 @@ class OptimizerService {
 		TrainingResult ...$results): float {
 		$costs = array_map(function (TrainingResult $result) use ($output) {
 			$output->writeln(sprintf("  Training result: f1=%f, p(n)=%f, r(n)=%f, f1(n)=%f, p(y)=%f, r(y)=%f, f1(y)=%f, PSR=%d/%d/%d",
-				$result->getReport()['overall']['f1_score'],
+				$result->getReport()['overall']['f1 score'],
 				$result->getReport()['classes']['n']['precision'],
 				$result->getReport()['classes']['n']['recall'],
-				$result->getReport()['classes']['n']['f1_score'],
+				$result->getReport()['classes']['n']['f1 score'],
 				$result->getReport()['classes']['y']['precision'],
 				$result->getReport()['classes']['y']['recall'],
-				$result->getReport()['classes']['y']['f1_score'],
+				$result->getReport()['classes']['y']['f1 score'],
 				$result->getModel()->getSamplesPositive(),
 				$result->getModel()->getSamplesShuffled(),
 				$result->getModel()->getSamplesRandom()
 			));
 			return (
-				$result->getReport()['classes']['n']['f1_score'] +
-				$result->getReport()['overall']['f1_score']
+				$result->getReport()['classes']['n']['f1 score'] +
+				$result->getReport()['overall']['f1 score']
 			) / 2;
 		}, $results);
 


### PR DESCRIPTION
In version 1.0.0-beta1 of RubixML, the attributes in the Report property changed their style from underscore to spaces (see [changelog](https://github.com/RubixML/ML/blob/master/CHANGELOG.md?plain=1#L232) as well as associated [commit](https://github.com/RubixML/ML/commit/959bbeaacda9cadbff0cd5f8307da3a38abed2e4)). This means that the f1_score were always 0.00 since the [bump of RubixML dependency in this commit](https://github.com/nextcloud/suspicious_login/commit/e0900fe3ff09465d1770b0e680ad6669172dafcb) (`dev-chore/bump-flysystem-v2.1.1` is based on RubixML v0.4.2). Can't say if that made the training totally broken or not (@ChristophWurst ?). 

Example output of a training epoch without change:

```
Epoch 0: epochs= 330 layers= 2 shuffledRate=0.005 randomRate=2.000, learningRate=0.0070
  Step width for next config neighbor: 0.8
  Training result: f1=0.000000, p(n)=0.972973, r(n)=0.947368, f1(n)=0.000000, p(y)=0.948718, r(y)=0.973684, f1(y)=0.000000, PSR=117/1/234
  Training result: f1=0.000000, p(n)=0.969697, r(n)=0.842105, f1(n)=0.000000, p(y)=0.860465, r(y)=0.973684, f1(y)=0.000000, PSR=117/1/234
  Training result: f1=0.000000, p(n)=0.972973, r(n)=0.947368, f1(n)=0.000000, p(y)=0.948718, r(y)=0.973684, f1(y)=0.000000, PSR=117/1/234
  Training result: f1=0.000000, p(n)=0.970588, r(n)=0.868421, f1(n)=0.000000, p(y)=0.880952, r(y)=0.973684, f1(y)=0.000000, PSR=117/1/234
  Training result: f1=0.000000, p(n)=0.972973, r(n)=0.947368, f1(n)=0.000000, p(y)=0.948718, r(y)=0.973684, f1(y)=0.000000, PSR=117/1/234
  Training result: f1=0.000000, p(n)=0.612903, r(n)=1.000000, f1(n)=0.000000, p(y)=1.000000, r(y)=0.368421, f1(y)=0.000000, PSR=117/1/234
  Training result: f1=0.000000, p(n)=0.972973, r(n)=0.947368, f1(n)=0.000000, p(y)=0.948718, r(y)=0.973684, f1(y)=0.000000, PSR=117/1/234
  Training result: f1=0.000000, p(n)=0.791667, r(n)=1.000000, f1(n)=0.000000, p(y)=1.000000, r(y)=0.736842, f1(y)=0.000000, PSR=117/1/234
  Base cost is 0. Trying to optimize this now …
```

Example output of a training epoch with change from this PR:

```
Epoch 0: epochs= 330 layers= 2 shuffledRate=0.005 randomRate=2.000, learningRate=0.0070
  Step width for next config neighbor: 0.8
  Training result: f1=0.947222, p(n)=0.904762, r(n)=1.000000, f1(n)=0.950000, p(y)=1.000000, r(y)=0.894737, f1(y)=0.944444, PSR=117/1/234
  Training result: f1=0.839323, p(n)=0.770833, r(n)=0.973684, f1(n)=0.860465, p(y)=0.964286, r(y)=0.710526, f1(y)=0.818182, PSR=117/1/234
  Training result: f1=0.986840, p(n)=0.974359, r(n)=1.000000, f1(n)=0.987013, p(y)=1.000000, r(y)=0.973684, f1(y)=0.986667, PSR=117/1/234
  Training result: f1=0.960519, p(n)=0.972973, r(n)=0.947368, f1(n)=0.960000, p(y)=0.948718, r(y)=0.973684, f1(y)=0.961039, PSR=117/1/234
  Training result: f1=0.788889, p(n)=0.761905, r(n)=0.842105, f1(n)=0.800000, p(y)=0.823529, r(y)=0.736842, f1(y)=0.777778, PSR=117/1/234
  Training result: f1=0.960519, p(n)=0.972973, r(n)=0.947368, f1(n)=0.960000, p(y)=0.948718, r(y)=0.973684, f1(y)=0.961039, PSR=117/1/234
  Training result: f1=0.960519, p(n)=0.972973, r(n)=0.947368, f1(n)=0.960000, p(y)=0.948718, r(y)=0.973684, f1(y)=0.961039, PSR=117/1/234
  Training result: f1=0.947332, p(n)=0.972222, r(n)=0.921053, f1(n)=0.945946, p(y)=0.925000, r(y)=0.973684, f1(y)=0.948718, PSR=117/1/234
  Base cost is 0.92591180270686. Trying to optimize this now …
```

Closes #1021.