### PR TITLE
Fix too short DataSet for shuffled samples when there is no unique IP address

### DIFF
--- a/lib/Service/NegativeSampleGenerator.php
+++ b/lib/Service/NegativeSampleGenerator.php
@@ -59,7 +59,7 @@ class NegativeSampleGenerator {
 	private function generateFromRealData(array $uidVec, array $uniqueIps): array {
 		return array_merge(
 			$uidVec,
-			empty($uniqueIps) ? [] : $uniqueIps[random_int(0, count($uniqueIps) - 1)]
+			$uniqueIps[random_int(0, count($uniqueIps) - 1)]
 		);
 	}
 
@@ -95,6 +95,10 @@ class NegativeSampleGenerator {
 	public function generateShuffledFromPositiveSamples(DataSet $positives, int $num): DataSet {
 		$max = count($positives);
 		$uniqueIps = $this->getUniqueIPsPerUser($positives);
+
+		if ($uniqueIps === []) {
+			return new Labeled();
+		}
 
 		return new Labeled(
 			array_map(function (int $id) use ($uniqueIps, $positives, $max) {

--- a/lib/Service/Statistics/AppStatistics.php
+++ b/lib/Service/Statistics/AppStatistics.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later

--- a/tests/Unit/Service/NegativeSampleGeneratorTest.php
+++ b/tests/Unit/Service/NegativeSampleGeneratorTest.php
@@ -112,20 +112,9 @@ class NegativeSampleGeneratorTest extends TestCase {
 			self::assertTrue(
 				$ipVec == self::decToBitArray(3, 32) ||
 				$ipVec === self::decToBitArray(4, 32),
-				'sample has a unique IP'
+				'Sample must have an unique IP'
 			);
 		}
-
-		$positives = new Unlabeled([
-			array_merge(self::decToBitArray(1, 16), self::decToBitArray(1, 32)),
-			array_merge(self::decToBitArray(2, 16), self::decToBitArray(1, 32)),
-			array_merge(self::decToBitArray(3, 16), self::decToBitArray(1, 32)),
-			array_merge(self::decToBitArray(4, 16), self::decToBitArray(1, 32)),
-		]);
-
-		$result = $this->generator->generateShuffledFromPositiveSamples($positives, 5);
-
-		self::assertCount(5, $result);
 	}
 
 	/**
@@ -154,9 +143,28 @@ class NegativeSampleGeneratorTest extends TestCase {
 			self::assertTrue(
 				$ipVec === self::decToBitArray(1, 32) ||
 				$ipVec === self::decToBitArray(2, 32),
-				'Sample has an unique IP'
+				'Sample must have an unique IP'
 			);
 		}
+	}
+
+	/**
+	 * Generating shuffled samples isn't possible when no user has an unique IP.
+	 * In that case, we have to return an empty Labeled() object as merging will
+	 * fail otherwise. See GitHub issue #860 for more.
+	 * @return void
+	 */
+	public function testGenerateShuffledFromDuplicatesOnly(): void {
+		$positives = new Unlabeled([
+			array_merge(self::decToBitArray(1, 16), self::decToBitArray(1, 32)),
+			array_merge(self::decToBitArray(2, 16), self::decToBitArray(1, 32)),
+			array_merge(self::decToBitArray(3, 16), self::decToBitArray(1, 32)),
+			array_merge(self::decToBitArray(4, 16), self::decToBitArray(1, 32)),
+		]);
+
+		$result = $this->generator->generateShuffledFromPositiveSamples($positives, 4);
+
+		self::assertCount(0, $result, 'Returned sample must be empty');
 	}
 
 	/**


### PR DESCRIPTION
Generating shuffled samples is based on IP addresses which are used exclusively by one user. If no user has such an unique IP address, the returned DataSet object contains no IP address at all. This results in an exception during merge with the "regular" DataSet objects due to the different length.

To mitigate this, I now return an empty `Labeled()` object which can be used in the `merge` function of RubixML without any issues. Additionally, I revert the change from #810 as `generateFromRealData` shouldn't be called without any unique IPs at all. I suspect that all people in #745 are affected by this bug in the first place and experience the error from #860 now.

This should fix the latest reports in #860.