### PR TITLE
fix(deps): remove rubix' stemmer and its dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,8 +6,10 @@
 		"amphp/amp": "^2.6.4",
 		"amphp/parallel": "^1.4.4",
 		"bamarni/composer-bin-plugin": "^1.8.2",
-		"rubix/ml": "^2.5.2",
-		"wamania/php-stemmer": "4.0 as 3.0"
+		"rubix/ml": "^2.5.2"
+	},
+	"replace": {
+		"wamania/php-stemmer": "*"
 	},
 	"license": "AGPLv3",
 	"authors": [
@@ -23,7 +25,11 @@
 		"test": "phpunit -c tests/phpunit.xml",
 		"test:unit": "phpunit -c tests/phpunit.xml tests/Unit",
 		"test:unit:dev": "phpunit -c tests/phpunit.xml tests/Unit --no-coverage",
-		"post-install-cmd": ["@composer bin all install --ansi"],
+		"post-install-cmd": [
+			"@composer bin all install --ansi",
+			"rm -f vendor/rubix/ml/benchmarks/Tokenizers/WordStemmerBench.php vendor/rubix/ml/src/Tokenizers/WordStemmer.php vendor/rubix/ml/docs/tokenizers/word-stemmer.md vendor/rubix/ml/tests/Tokenizers/WordStemmerTest.php",
+			"@composer dump-autoload"
+		],
 		"psalm": "psalm --threads=1",
 		"psalm:update-baseline": "psalm --threads=1 --update-baseline",
 		"psalm:update-baseline:force": "psalm --threads=1 --update-baseline --set-baseline=tests/psalm-baseline.xml",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f1b61822cb021b9a2d676aca262f214b",
+    "content-hash": "216ee3a60047f3c427054ad6907c6490",
     "packages": [
         {
             "name": "amphp/amp",
@@ -614,85 +614,6 @@
             "time": "2022-10-31T08:38:03+00:00"
         },
         {
-            "name": "joomla/string",
-            "version": "3.0.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/joomla-framework/string.git",
-                "reference": "0b3d33564db389e27346f7e275c694897c939434"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/joomla-framework/string/zipball/0b3d33564db389e27346f7e275c694897c939434",
-                "reference": "0b3d33564db389e27346f7e275c694897c939434",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^8.1.0",
-                "symfony/deprecation-contracts": "^2|^3"
-            },
-            "conflict": {
-                "doctrine/inflector": "<1.2"
-            },
-            "require-dev": {
-                "doctrine/inflector": "^1.2",
-                "joomla/test": "^3.0",
-                "phpstan/phpstan": "1.12.27",
-                "phpstan/phpstan-deprecation-rules": "1.2.1",
-                "phpunit/phpunit": "^9.5.28",
-                "squizlabs/php_codesniffer": "^3.7.2"
-            },
-            "suggest": {
-                "doctrine/inflector": "To use the string inflector",
-                "ext-mbstring": "For improved processing"
-            },
-            "type": "joomla-package",
-            "extra": {
-                "branch-alias": {
-                    "dev-2.0-dev": "2.0-dev",
-                    "dev-3.x-dev": "3.0-dev"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "src/phputf8/utf8.php",
-                    "src/phputf8/ord.php",
-                    "src/phputf8/str_ireplace.php",
-                    "src/phputf8/str_pad.php",
-                    "src/phputf8/str_split.php",
-                    "src/phputf8/strcasecmp.php",
-                    "src/phputf8/strcspn.php",
-                    "src/phputf8/stristr.php",
-                    "src/phputf8/strrev.php",
-                    "src/phputf8/strspn.php",
-                    "src/phputf8/trim.php",
-                    "src/phputf8/ucfirst.php",
-                    "src/phputf8/ucwords.php",
-                    "src/phputf8/utils/ascii.php",
-                    "src/phputf8/utils/validation.php"
-                ],
-                "psr-4": {
-                    "Joomla\\String\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "description": "Joomla String Package",
-            "homepage": "https://github.com/joomla-framework/string",
-            "keywords": [
-                "framework",
-                "joomla",
-                "string"
-            ],
-            "support": {
-                "issues": "https://github.com/joomla-framework/string/issues",
-                "source": "https://github.com/joomla-framework/string/tree/3.0.4"
-            },
-            "time": "2025-07-19T15:25:56+00:00"
-        },
-        {
             "name": "psr/log",
             "version": "3.0.2",
             "source": {
@@ -1007,73 +928,6 @@
             "time": "2024-03-15T19:43:50+00:00"
         },
         {
-            "name": "symfony/deprecation-contracts",
-            "version": "v3.6.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/contracts",
-                    "name": "symfony/contracts"
-                },
-                "branch-alias": {
-                    "dev-main": "3.6-dev"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "function.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "A generic function and convention to trigger deprecation notices",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2024-09-25T14:21:43+00:00"
-        },
-        {
             "name": "symfony/polyfill-mbstring",
             "version": "v1.31.0",
             "source": {
@@ -1384,66 +1238,10 @@
                 }
             ],
             "time": "2024-09-09T11:45:10+00:00"
-        },
-        {
-            "name": "wamania/php-stemmer",
-            "version": "v4.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/wamania/php-stemmer.git",
-                "reference": "d96509294ea843b4b86e4900df27424a6ea0ace8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/wamania/php-stemmer/zipball/d96509294ea843b4b86e4900df27424a6ea0ace8",
-                "reference": "d96509294ea843b4b86e4900df27424a6ea0ace8",
-                "shasum": ""
-            },
-            "require": {
-                "joomla/string": ">=2.0.1",
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Wamania\\Snowball\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Wamania",
-                    "homepage": "http://wamania.com"
-                }
-            ],
-            "description": "Native PHP Stemmer",
-            "keywords": [
-                "php",
-                "porter",
-                "stemmer"
-            ],
-            "support": {
-                "issues": "https://github.com/wamania/php-stemmer/issues",
-                "source": "https://github.com/wamania/php-stemmer/tree/v4.0.0"
-            },
-            "time": "2024-12-22T08:54:03+00:00"
         }
     ],
     "packages-dev": [],
-    "aliases": [
-        {
-            "package": "wamania/php-stemmer",
-            "version": "4.0.0.0",
-            "alias": "3.0",
-            "alias_normalized": "3.0.0.0"
-        }
-    ],
+    "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {},
     "prefer-stable": false,


### PR DESCRIPTION
Fixes https://github.com/nextcloud/suspicious_login/issues/1037

This app doesn't use stemming. There is no natural language processing, just IP addresses (numbers). Therefore, we don't need the conflicting libs.

```
Updating dependencies
Lock file operations: 0 installs, 0 updates, 3 removals
  - Removing joomla/string (3.0.4)
  - Removing symfony/deprecation-contracts (v3.6.0)
  - Removing wamania/php-stemmer (v4.0.0)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 0 installs, 0 updates, 3 removals
  - Removing wamania/php-stemmer (v4.0.0)
  - Removing symfony/deprecation-contracts (v3.6.0)
  - Removing joomla/string (3.0.4)
Generating optimized autoload files
```

@cyberpower678 @DerDreschner @marcelklehr please have a look

- [x] https://github.com/nextcloud/suspicious_login/pull/1039 for green CI