### PR TITLE
fix(IPv6): Ignore scope identifier in IPv6 addresses

### DIFF
--- a/lib/Service/IpV6Strategy.php
+++ b/lib/Service/IpV6Strategy.php
@@ -12,6 +12,7 @@ namespace OCA\SuspiciousLogin\Service;
 use InvalidArgumentException;
 use OCA\SuspiciousLogin\Db\LoginAddressAggregatedMapper;
 use OCA\SuspiciousLogin\Service\MLP\Config;
+use OCA\SuspiciousLogin\Util\IPv6AddressParser;
 use function array_map;
 use function base_convert;
 use function bin2hex;
@@ -38,7 +39,8 @@ class IpV6Strategy extends AClassificationStrategy {
 
 	#[\Override]
 	protected function ipToVec(string $ip): array {
-		$addr = inet_pton($ip);
+		$strippedIp = IPv6AddressParser::stripScopeIdentifier($ip);
+		$addr = inet_pton($strippedIp);
 		if ($addr === false) {
 			throw new InvalidArgumentException('Invalid IPv6 address');
 		}

--- a/lib/Util/AddressClassifier.php
+++ b/lib/Util/AddressClassifier.php
@@ -17,6 +17,9 @@ class AddressClassifier {
 	}
 
 	public static function isIpV6(string $address): bool {
-		return filter_var($address, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) !== false;
+		$strippedAddress = IPv6AddressParser::stripScopeIdentifier($address);
+
+		return filter_var($strippedAddress, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) !== false;
 	}
+
 }

--- a/lib/Util/IPv6AddressParser.php
+++ b/lib/Util/IPv6AddressParser.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\SuspiciousLogin\Util;
+
+final class IPv6AddressParser {
+	/**
+	 * As described in RFC 4007, IPv6 addresses may include an optional
+	 * scope identifier attached to the end (e.g., `%eth1`). We must
+	 * filter out the scope, as the current model doesn't support
+	 * processing this information.
+	 */
+	public static function stripScopeIdentifier(string $address): string {
+		$delimiterPosition = strpos($address, '%');
+		$scopeIdentifierExists = $delimiterPosition !== false;
+
+		return $scopeIdentifierExists
+			? substr($address, 0, $delimiterPosition)
+			: $address;
+	}
+}

--- a/tests/Unit/Util/AddressClassifierTest.php
+++ b/tests/Unit/Util/AddressClassifierTest.php
@@ -13,7 +13,7 @@ use ChristophWurst\Nextcloud\Testing\TestCase;
 use OCA\SuspiciousLogin\Util\AddressClassifier;
 
 class AddressClassifierTest extends TestCase {
-	public function ipV4Data(): array {
+	public static function ipV4Data(): array {
 		return [
 			['1.2.3.4', true],
 			['12.34.56.78', true],
@@ -33,7 +33,7 @@ class AddressClassifierTest extends TestCase {
 		$this->assertEquals($expected, $isIpV4);
 	}
 
-	public function ipV6Data(): array {
+	public static function ipV6Data(): array {
 		return [
 			['1.2.3.4', false],
 			['12.34.56.78', false],
@@ -41,6 +41,7 @@ class AddressClassifierTest extends TestCase {
 			['123.123.123.123', false],
 			['1234.1234.1234.1234', false],
 			['::1', true],
+			['fe80::1%eth0', true],
 			['2001:0db8:85a3:0000:0000:8a2e:0370:7334', true],
 			['::ffff:192.0.2.128', true],
 		];

--- a/tests/Unit/Util/IPv6AddressParserTest.php
+++ b/tests/Unit/Util/IPv6AddressParserTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\SuspiciousLogin\Tests\Unit\Util;
+
+use ChristophWurst\Nextcloud\Testing\TestCase;
+use OCA\SuspiciousLogin\Util\IPv6AddressParser;
+
+class IPv6AddressParserTest extends TestCase {
+	public static function stripScopeIdentifierData(): array {
+		return [
+			// No scope identifier – address returned unchanged
+			['::1', '::1'],
+			['fe80::1', 'fe80::1'],
+			['2001:0db8:85a3:0000:0000:8a2e:0370:7334', '2001:0db8:85a3:0000:0000:8a2e:0370:7334'],
+			// Typical scope identifier
+			['fe80::1%eth0', 'fe80::1'],
+			['fe80::1%lo', 'fe80::1'],
+			// Trailing % (empty zone id)
+			['fe80::1%', 'fe80::1'],
+			// Multiple % – only the first delimiter counts
+			['fe80::1%eth0%extra', 'fe80::1'],
+			// Non-IPv6 input that contains %
+			['1.2.3.4%eth0', '1.2.3.4'],
+			['example.com%zone', 'example.com'],
+			// Empty string
+			['', ''],
+		];
+	}
+
+	/**
+	 * @dataProvider stripScopeIdentifierData
+	 */
+	public function testStripScopeIdentifier(string $input, string $expected): void {
+		$result = IPv6AddressParser::stripScopeIdentifier($input);
+
+		$this->assertSame($expected, $result);
+	}
+}


### PR DESCRIPTION
- Resolves #1087 

## Summary

IPv6 addresses may contain a scope identifier at the end (e.g., `%eth1`, see [RFC 4007](https://datatracker.ietf.org/doc/html/rfc4007)). This case isn't handled by our code right now and throws an `InvalidArgumentException`. As workaround, I would suggest stripping the scope entirely.

Integrating it into the current model isn't very practical in my opinion, as the length of the scope identifier isn't limited and we can only use a few characters before the vector dimensions grow too large.

AI-assisted: Claude Code (claude-sonnet-4-6)