### PR TITLE
ci: fix profile workflow undefined server checkout ref

### DIFF
--- a/.github/workflows/profile.yml
+++ b/.github/workflows/profile.yml
@@ -62,7 +62,7 @@ jobs:
           persist-credentials: false
           submodules: true
           repository: nextcloud/server
-          ref: ${{ matrix.nextcloud-versions }}
+          ref: ${{ matrix.nextcloud-version }}
           path: nextcloud
 
       - name: Install Nextcloud


### PR DESCRIPTION
As a regression of https://github.com/nextcloud/suspicious_login/pull/1046 the server checkout was no longer set so it always picked master. That's fine for master but fails on stable33.