### PR TITLE
fix(notifier): Fix label length limited to 32 characters

### DIFF
--- a/lib/Notifications/Notifier.php
+++ b/lib/Notifications/Notifier.php
@@ -77,7 +77,7 @@ class Notifier implements INotifier {
 					$action = $notification->createAction();
 					$label = $l->t('Open %s ↗', ['iplookup.flagfox.net']);
 					$link = 'https://iplookup.flagfox.net/?ip=' . $suspiciousIp;
-					$action->setLabel($label)
+					$action->setLabel('open_iplookup')
 						->setParsedLabel($label)
 						->setLink($link, IAction::TYPE_WEB)
 						->setPrimary(true);


### PR DESCRIPTION
Limited to 32 chars since ever:
https://github.com/nextcloud/server/blob/1ab09ec753f106661beadee1794b390ebec455dd/lib/private/Notification/Action.php#L27-L29

Currently the notification does not work for the following languages:
- ar
- be
- cs
- el
- fa
- hu
- ja
- sk
- sr
- ug
- uk
- uz

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
