### PR TITLE
chore(psalm): remove obsolete UndefinedDocblockClass suppressions

### DIFF
--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -35,10 +35,13 @@ jobs:
       - name: Check enforcement of minimum PHP version ${{ steps.versions.outputs.php-min }} in psalm.xml
         run: grep 'phpVersion="${{ steps.versions.outputs.php-min }}' psalm.xml
 
-      - name: Set up php${{ steps.versions.outputs.php-available }}
+      # Run Psalm on the minimum supported PHP version (matches psalm.xml's
+      # phpVersion) instead of php-available: Psalm 6.16.1 crashes on PHP 8.5
+      # while stringifying rubix/ml's `const OUTLIER_VALUE = NAN`.
+      - name: Set up php${{ steps.versions.outputs.php-min }}
         uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2.37.0
         with:
-          php-version: ${{ steps.versions.outputs.php-available }}
+          php-version: ${{ steps.versions.outputs.php-min }}
           extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite
           coverage: none
           ini-file: development

--- a/psalm.xml
+++ b/psalm.xml
@@ -45,13 +45,5 @@
 				<referencedClass name="Symfony\Component\Console\Helper\ProgressBar" />
 			</errorLevel>
 		</UndefinedClass>
-		<UndefinedDocblockClass>
-			<errorLevel type="suppress">
-				<referencedClass name="Doctrine\DBAL\Driver\Statement" />
-				<referencedClass name="Doctrine\DBAL\Schema\Schema" />
-				<referencedClass name="Doctrine\DBAL\Schema\SchemaException" />
-				<referencedClass name="Doctrine\DBAL\Schema\Table" />
-			</errorLevel>
-		</UndefinedDocblockClass>
 	</issueHandlers>
 </psalm>


### PR DESCRIPTION
Addresses the red CI of https://github.com/nextcloud/suspicious_login/pull/1132.

NC36's OCP no longer references Doctrine\DBAL\Driver\Statement in its docblocks, so the UndefinedDocblockClass suppression for it is never hit and Psalm reports it as an UnusedIssueHandlerSuppression.

Assisted-by: ClaudeCode:claude-opus-4-8



## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
