### PR TITLE
fix: avoid double app password check

### DIFF
--- a/lib/Service/LoginClassifier.php
+++ b/lib/Service/LoginClassifier.php
@@ -20,11 +20,6 @@ use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IRequest;
 use Psr\Log\LoggerInterface;
 use Throwable;
-use function base64_decode;
-use function explode;
-use function preg_match;
-use function strlen;
-use function substr;
 
 class LoginClassifier {
 
@@ -38,37 +33,7 @@ class LoginClassifier {
 	) {
 	}
 
-	/**
-	 * @todo find a more reliable way of checking this
-	 */
-	private function isAuthenticatedWithAppPassword(IRequest $request): bool {
-		$authHeader = $request->getHeader('Authorization');
-		if (empty($authHeader)) {
-			return false;
-		}
-		if (!str_starts_with($authHeader, 'Basic ')) {
-			return false;
-		}
-		$pwd = explode(
-			':',
-			base64_decode(substr($authHeader, strlen('Basic ')))
-		);
-		if (!isset($pwd[1])) {
-			return false;
-		}
-
-		return preg_match(
-			'/^([0-9A-Za-z]{5})-([0-9A-Za-z]{5})-([0-9A-Za-z]{5})-([0-9A-Za-z]{5})-([0-9A-Za-z]{5})$/',
-			$pwd[1]
-		) === 1;
-	}
-
 	public function process(string $uid, string $ip) {
-		if ($this->isAuthenticatedWithAppPassword($this->request)) {
-			// We don't care about those logins
-			$this->logger->debug('App password detected. No address classification is performed');
-			return;
-		}
 		try {
 			$strategy = AddressClassifier::isIpV4($ip) ? new Ipv4Strategy() : new IpV6Strategy();
 			if ($this->estimator->predict($uid, $ip, $strategy)) {

--- a/tests/Unit/Service/LoginClassifierTest.php
+++ b/tests/Unit/Service/LoginClassifierTest.php
@@ -168,4 +168,23 @@ class LoginClassifierTest extends TestCase {
 
 		$this->classifier->process('user', '1.2.3.4');
 	}
+
+	public function testProcessClassifiesRealPasswordShapedLikeAppPassword(): void {
+		// A genuine account password that happens to match the app-password display format.
+		$realPassword = 'abcde-fghij-klmno-pqrst-uvwxy';
+		$this->request->method('getHeader')
+			->with('Authorization')
+			->willReturn('Basic ' . base64_encode('user:' . $realPassword));
+		$this->timeFactory->method('getTime')->willReturn(1000000);
+		$this->estimatorService->expects(self::once())
+			->method('predict')
+			->with('user', '1.2.3.4', self::equalTo(new Ipv4Strategy()))
+			->willReturn(false);
+		$this->mapper->method('findRelated')->willReturn([]);
+		$this->mapper->method('findRecentByUid')->willReturn([]);
+		$this->dispatcher->expects(self::once())
+			->method('dispatchTyped');
+
+		$this->classifier->process('user', '1.2.3.4');
+	}
 }


### PR DESCRIPTION
The server already tests the password to be an app password and passes that info through the event. The login listener has an early exit. Yet this app also tested the shape of the password, which can lead to false negatives.

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
